### PR TITLE
Remove treasury collateralization ratio

### DIFF
--- a/contracts/Entity.sol
+++ b/contracts/Entity.sol
@@ -8,8 +8,6 @@ contract Entity is Controller, Proxy {
   constructor (address _settings, address _entityAdmin, bytes32 _entityContext) Controller(_settings) Proxy() public {
     _setDelegateAddress(settings().getRootAddress(SETTING_ENTITY_DELEGATE));
 
-    dataUint256["treasuryCollRatioBP"] = 10000;
-
     if (_entityContext != "") {
       dataBytes32["aclContext"] = _entityContext;
     } else {

--- a/contracts/EntityTreasuryBridgeFacet.sol
+++ b/contracts/EntityTreasuryBridgeFacet.sol
@@ -27,24 +27,11 @@ import "./base/SafeMath.sol";
   function getSelectors () public pure override returns (bytes memory) {
     return abi.encodePacked(
       IEntityTreasuryBridgeFacet.transferFromTreasury.selector,
-      IEntityTreasuryBridgeFacet.transferToTreasury.selector,
-      IEntityTreasuryBridgeFacet.getCollateralRatio.selector,
-      IEntityTreasuryBridgeFacet.setCollateralRatio.selector
+      IEntityTreasuryBridgeFacet.transferToTreasury.selector
     );
   }
 
   // IEntityTreasuryBridgeFacet
-
-  function getCollateralRatio() public view override returns (
-    uint256 treasuryCollRatioBP_
-  ) {
-    treasuryCollRatioBP_ = dataUint256["treasuryCollRatioBP"];
-  }
-
-  function setCollateralRatio(uint256 _treasuryCollRatioBP) external override assertIsEntityAdmin(msg.sender) {
-    require(_treasuryCollRatioBP > 0, "cannot be 0");
-    dataUint256["treasuryCollRatioBP"] = _treasuryCollRatioBP;
-  }
 
   function transferToTreasury(address _unit, uint256 _amount) external override {
     _assertHasEnoughBalance(_unit, _amount);
@@ -58,12 +45,7 @@ import "./base/SafeMath.sol";
   function transferFromTreasury(address _unit, uint256 _amount) external override {
     // check if we have enough balance
     string memory trbKey = __a(_unit, "treasuryRealBalance");
-    string memory tmbKey = __a(_unit, "treasuryMinBalance");
     require(dataUint256[trbKey] >= _amount, "exceeds treasury balance");
-
-    // check if minimum coll ratio is maintained
-    uint256 collBal = dataUint256[tmbKey].mul(10000 * dataUint256["treasuryCollRatioBP"]).div(10000 * 10000);
-    require(dataUint256[trbKey].sub(_amount) >= collBal, "collateral too low");
 
     dataUint256[trbKey] = dataUint256[trbKey].sub(_amount);
     dataUint256[__a(_unit, "balance")] = dataUint256[__a(_unit, "balance")].add(_amount);

--- a/contracts/base/IEntityTreasuryBridgeFacet.sol
+++ b/contracts/base/IEntityTreasuryBridgeFacet.sol
@@ -5,22 +5,6 @@ pragma solidity 0.6.12;
  */
 interface IEntityTreasuryBridgeFacet {
   /**
-   * @dev Get treasury collaterlization ratio.
-   *
-   * @return treasuryCollRatioBP_ Treasury collateralization ratio.
-   */
-  function getCollateralRatio() external view returns (
-    uint256 treasuryCollRatioBP_
-  );
-
-  /**
-   * @dev Set treasury collateralization raiot.
-   *
-   * @param _treasuryCollRatioBP Treasury collateralization ratio basis points.
-   */
-  function setCollateralRatio(uint256 _treasuryCollRatioBP) external;
-
-  /**
    * @dev Transfer assets from the internal balance to the treasury balance.
    *
    * @param _unit Asset to move.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,11 +92,9 @@ Entities can create policies, though the rule is that the entity itself must be 
 
 Entities also have an internal _treasury_ which is where policy collateral (and premium payments) is actually stored. Funds can be transferred between the entity's "normal" balance and its treasury balance as long as its treasury's collateralization ratio is honoured.
 
-The treasury has a _virtual balance_, which is the balance it expects to have according to the policies it has collateralized as well as pending claims. It has a _real/actual balance_, which is its real balance. And it has a collateralization ratio set, which is essentially of the virtual balance to the real balance. 
+The treasury has a _virtual balance_, which is the balance it expects to have according to the policies it has collateralized as well as pending claims. It has a _real/actual balance_, which is its real balance.
 
-_For example, if the collateraliation ration is 25% then the real balance must always be atleast 25% of the virtual balance._
-
-![entity](https://user-images.githubusercontent.com/266594/118809113-1a46ea80-b8a2-11eb-94e6-ca53a70e35fd.png)
+![entity treasury](https://user-images.githubusercontent.com/266594/123963705-a1f83c80-d9aa-11eb-9ba5-b106d0f96a72.png)
 
 When a claim needs to be paid out and there is not enough balance to do so, the claim gets added to the internal claim queue in the treasury. As soon as new funds are received (via transfer from the entity "normal" balance) any pending claims get paid out automatically in the order in which they were originally created (FIFO):
 

--- a/test/treasury.js
+++ b/test/treasury.js
@@ -128,25 +128,6 @@ contract('Treasury', accounts => {
     expect(entityProxy.address).to.exist
   })
 
-  describe('has a collateralization ratio', () => {
-    it('with default as 100', async () => {
-      await entity.getCollateralRatio().should.eventually.eq(10000)
-    })
-
-    it('which can be set, but not just by anyone', async () => {
-      await entity.setCollateralRatio(500, { from: accounts[2] }).should.be.rejectedWith('must be entity admin')
-    })
-
-    it('which can be set', async () => {
-      await entity.setCollateralRatio(500, { from: entityAdminAddress })
-      await entity.getCollateralRatio().should.eventually.eq(500)
-    })
-
-    it('which cannot be set to 0', async () => {
-      await entity.setCollateralRatio(0, { from: entityAdminAddress }).should.be.rejectedWith('cannot be 0')
-    })
-  })
-
   describe('can have policy balance updated', async () => {
     it('but not for a non-policy', async () => {
       await treasury.incPolicyBalance(0, { from: accounts[0] }).should.be.rejectedWith('not my policy')
@@ -656,84 +637,6 @@ contract('Treasury', accounts => {
         })
 
         await entity.transferFromTreasury(etherToken.address, 6).should.be.rejectedWith('exceeds treasury balance')
-      })
-
-      describe('and takes into account collateralization ratio', async () => {
-        beforeEach(async () => {
-          await policies[0].testFacet.treasuryIncPolicyBalance(4)
-          await policies[0].testFacet.treasurySetMinPolicyBalance(3)
-
-          await policies[1].testFacet.treasuryIncPolicyBalance(7)
-          await policies[1].testFacet.treasurySetMinPolicyBalance(6)
-
-          await treasury.getEconomics(etherToken.address).should.eventually.matchObj({
-            realBalance_: 11,
-            virtualBalance_: 11,
-            minBalance_: 9,
-          })
-
-          await entity.getBalance(etherToken.address).should.eventually.eq(0)
-        })
-
-        it('when at 100%', async () => {
-          await entity.setCollateralRatio(10000)
-
-          await entity.transferFromTreasury(etherToken.address, 3).should.be.rejectedWith("collateral too low")
-          
-          await entity.transferFromTreasury(etherToken.address, 2).should.be.fulfilled
-
-          await treasury.getEconomics(etherToken.address).should.eventually.matchObj({
-            realBalance_: 9,
-            virtualBalance_: 11,
-            minBalance_: 9,
-          })
-
-          await entity.getBalance(etherToken.address).should.eventually.eq(2)
-        })
-
-        it('when at 0.1%', async () => {
-          await entity.setCollateralRatio(1)
-
-          await entity.transferFromTreasury(etherToken.address, 11).should.be.fulfilled
-
-          await treasury.getEconomics(etherToken.address).should.eventually.matchObj({
-            realBalance_: 0,
-            virtualBalance_: 11,
-            minBalance_: 9,
-          })
-
-          await entity.getBalance(etherToken.address).should.eventually.eq(11)
-        })
-
-        it('when at 1%', async () => {
-          await entity.setCollateralRatio(100)
-
-          await entity.transferFromTreasury(etherToken.address, 11).should.be.fulfilled
-
-          await treasury.getEconomics(etherToken.address).should.eventually.matchObj({
-            realBalance_: 0,
-            virtualBalance_: 11,
-            minBalance_: 9,
-          })
-
-          await entity.getBalance(etherToken.address).should.eventually.eq(11)
-        })
-
-        it('when at 12%', async () => {
-          await entity.setCollateralRatio(1200)
-
-          await entity.transferFromTreasury(etherToken.address, 11).should.be.rejectedWith('collateral too low')
-
-          await entity.transferFromTreasury(etherToken.address, 10).should.be.fulfilled
-
-          await treasury.getEconomics(etherToken.address).should.eventually.matchObj({
-            realBalance_: 1,
-            virtualBalance_: 11,
-            minBalance_: 9,
-          })
-
-          await entity.getBalance(etherToken.address).should.eventually.eq(10)
-        })
       })
     })
   })


### PR DESCRIPTION
The collateralization ratio no longer applies, so we'll remove it.