### PR TITLE
CU-jf4uv5 CU-1jzahap Also corrected spelling mistake for tranche

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ yarn test
 To run a single test:
 
 ```shell
-yarn truffle test ./test/testName.js --network test
+yarn hardhat test ./test/testName.js
 ```
 
 You can use the admin dapp to interact with your locally deployed contracts. 

--- a/contracts/CommonUpgradeFacet.sol
+++ b/contracts/CommonUpgradeFacet.sol
@@ -15,8 +15,8 @@ contract CommonUpgradeFacet is Controller, IDiamondUpgradeFacet {
   }
 
   function getVersionInfo () public override pure returns (string memory num_, uint256 date_, string memory hash_) {
-    num_ = "1.0.0-local.1637670508474";
-    date_ = 1637670508;
-    hash_ = "5dd2a96bb7d67f9b4c5830677195c4d14004e965";
+    num_ = "1.0.0-local.1637832747874";
+    date_ = 1637832747;
+    hash_ = "7af44b9ce0b5786437d182ee1ba7290eee1c4003";
   }
 }

--- a/contracts/EntityCoreFacet.sol
+++ b/contracts/EntityCoreFacet.sol
@@ -17,7 +17,7 @@ import "./Policy.sol";
 contract EntityCoreFacet is EternalStorage, Controller, EntityFacetBase, IEntityCoreFacet, IDiamondFacet {
   using SafeMath for uint256;
 
-  modifier assertCanPayTranchPremiums (address _policyAddress) {
+  modifier assertCanPayTranchePremiums (address _policyAddress) {
     require(inRoleGroup(msg.sender, ROLEGROUP_ENTITY_REPS), 'must be entity rep');
     _;
   }
@@ -33,7 +33,7 @@ contract EntityCoreFacet is EternalStorage, Controller, EntityFacetBase, IEntity
   function getSelectors () public pure override returns (bytes memory) {
     return abi.encodePacked(
       IEntityCoreFacet.createPolicy.selector,
-      IEntityCoreFacet.payTranchPremium.selector,
+      IEntityCoreFacet.payTranchePremium.selector,
       IParent.getNumChildren.selector,
       IParent.getChild.selector,
       IParent.hasChild.selector
@@ -45,7 +45,7 @@ contract EntityCoreFacet is EternalStorage, Controller, EntityFacetBase, IEntity
 
   function createPolicy(
     bytes32 _id,
-    uint256[] calldata _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP,
+    uint256[] calldata _typeAndDatesAndCommissionsBP,
     address[] calldata _unitAndTreasuryAndStakeholders,
     uint256[][] calldata _trancheData,
     bytes[] calldata _approvalSignatures
@@ -62,7 +62,7 @@ contract EntityCoreFacet is EternalStorage, Controller, EntityFacetBase, IEntity
       _id,
       address(settings()),
       msg.sender,
-      _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP,
+      _typeAndDatesAndCommissionsBP,
       _unitAndTreasuryAndStakeholders
     );
 
@@ -81,7 +81,7 @@ contract EntityCoreFacet is EternalStorage, Controller, EntityFacetBase, IEntity
         premiums[j - 2] = _trancheData[i][j];
       }
 
-      pol.createTranch(
+      pol.createTranche(
         _trancheData[i][0], // _numShares
         _trancheData[i][1], // _pricePerShareAmount
         premiums
@@ -96,10 +96,10 @@ contract EntityCoreFacet is EternalStorage, Controller, EntityFacetBase, IEntity
   }
   
 
-  function payTranchPremium(address _policy, uint256 _tranchIndex, uint256 _amount)
+  function payTranchePremium(address _policy, uint256 _trancheIndex, uint256 _amount)
     external
     override
-    assertCanPayTranchPremiums(_policy)
+    assertCanPayTranchePremiums(_policy)
   {
     address policyUnitAddress;
 
@@ -113,7 +113,7 @@ contract EntityCoreFacet is EternalStorage, Controller, EntityFacetBase, IEntity
       address a1;
 
       // policy's unit
-      (, a1, i1, i2, i3, policyUnitAddress, , , ,) = p.getInfo();
+      (, a1, i1, i2, i3, policyUnitAddress, , ,) = p.getInfo();
     }
     
     // check balance
@@ -124,6 +124,6 @@ contract EntityCoreFacet is EternalStorage, Controller, EntityFacetBase, IEntity
     tok.approve(_policy, _amount);
 
     // do it
-    p.payTranchPremium(_tranchIndex, _amount);
+    p.payTranchePremium(_trancheIndex, _amount);
   }
 }

--- a/contracts/EntityFundingFacet.sol
+++ b/contracts/EntityFundingFacet.sol
@@ -13,7 +13,7 @@ import "./EntityFacetBase.sol";
 contract EntityFundingFacet is EternalStorage, Controller, EntityFacetBase, IEntityFundingFacet, IDiamondFacet {
   using SafeMath for uint256;
 
-  modifier assertCanTradeTranchTokens () {
+  modifier assertCanTradeTrancheTokens () {
     require(inRoleGroup(msg.sender, ROLEGROUP_TRADERS), 'must be trader');
     _;
   }
@@ -74,7 +74,7 @@ contract EntityFundingFacet is EternalStorage, Controller, EntityFacetBase, IEnt
   function trade(address _payUnit, uint256 _payAmount, address _buyUnit, uint256 _buyAmount)
     external
     override
-    assertCanTradeTranchTokens
+    assertCanTradeTrancheTokens
     returns (uint256)
   {
     // check balance
@@ -86,7 +86,7 @@ contract EntityFundingFacet is EternalStorage, Controller, EntityFacetBase, IEnt
   function sellAtBestPrice(address _sellUnit, uint256 _sellAmount, address _buyUnit)
     external
     override
-    assertCanTradeTranchTokens
+    assertCanTradeTrancheTokens
   {
     // check balance
     _assertHasEnoughBalance(_sellUnit, _sellAmount);

--- a/contracts/EntityTreasuryFacetBase.sol
+++ b/contracts/EntityTreasuryFacetBase.sol
@@ -19,7 +19,7 @@ abstract contract EntityTreasuryFacetBase is EntityFacetBase, IPolicyTreasuryCon
       uint256 i2;
       uint256 i3;
       address a1;
-      (, a1, i1, i2, i3, policyUnitAddress, , , ,) = IPolicyCoreFacet(_policy).getInfo();
+      (, a1, i1, i2, i3, policyUnitAddress, , ,) = IPolicyCoreFacet(_policy).getInfo();
     }
 
     return policyUnitAddress;

--- a/contracts/Policy.sol
+++ b/contracts/Policy.sol
@@ -12,7 +12,7 @@ contract Policy is Controller, Proxy, PolicyFacetBase, Child {
     bytes32 _id,
     address _settings,
     address _caller,
-    uint256[] memory _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP,
+    uint256[] memory _typeAndDatesAndCommissionsBP,
     address[] memory _unitAndTreasuryAndStakeholders
   ) Controller(_settings) Proxy() public
   {
@@ -22,15 +22,24 @@ contract Policy is Controller, Proxy, PolicyFacetBase, Child {
 
     // set properties
     dataBytes32["id"] = _id;
-    dataUint256["type"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[0];
-    dataUint256["premiumIntervalSeconds"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[1];
-    dataUint256["initiationDate"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[2];
-    dataUint256["startDate"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[3];
-    dataUint256["maturationDate"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[4];
-    dataUint256["brokerCommissionBP"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[5];
-    dataUint256["underwriterCommissionBP"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[6];
-    dataUint256["claimsAdminCommissionBP"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[7];
-    dataUint256["naymsCommissionBP"] = _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP[8];
+    dataUint256["type"] = _typeAndDatesAndCommissionsBP[0];
+    // dataUint256["premiumIntervalSeconds"] = _typeAndDatesAndCommissionsBP[1];
+    // dataUint256["initiationDate"] = _typeAndDatesAndCommissionsBP[2];
+    // dataUint256["startDate"] = _typeAndDatesAndCommissionsBP[3];
+    // dataUint256["maturationDate"] = _typeAndDatesAndCommissionsBP[4];
+    // dataUint256["brokerCommissionBP"] = _typeAndDatesAndCommissionsBP[5];
+    // dataUint256["underwriterCommissionBP"] = _typeAndDatesAndCommissionsBP[6];
+    // dataUint256["claimsAdminCommissionBP"] = _typeAndDatesAndCommissionsBP[7];
+    // dataUint256["naymsCommissionBP"] = _typeAndDatesAndCommissionsBP[8];
+
+    dataUint256["initiationDate"] = _typeAndDatesAndCommissionsBP[1];
+    dataUint256["startDate"] = _typeAndDatesAndCommissionsBP[2];
+    dataUint256["maturationDate"] = _typeAndDatesAndCommissionsBP[3];
+    dataUint256["brokerCommissionBP"] = _typeAndDatesAndCommissionsBP[4];
+    dataUint256["underwriterCommissionBP"] = _typeAndDatesAndCommissionsBP[5];
+    dataUint256["claimsAdminCommissionBP"] = _typeAndDatesAndCommissionsBP[6];
+    dataUint256["naymsCommissionBP"] = _typeAndDatesAndCommissionsBP[7];
+    
     dataAddress["unit"] = _unitAndTreasuryAndStakeholders[0];
     dataAddress["treasury"] = _unitAndTreasuryAndStakeholders[1];
 

--- a/contracts/PolicyFacetBase.sol
+++ b/contracts/PolicyFacetBase.sol
@@ -39,10 +39,10 @@ abstract contract PolicyFacetBase is EternalStorage, IPolicyStates, AccessContro
     }
   }
 
-  function _setTranchState (uint256 _tranchIndex, uint256 _newState) internal {
-    if (dataUint256[__i(_tranchIndex, "state")] != _newState) {
-      dataUint256[__i(_tranchIndex, "state")] = _newState;
-      emit TranchStateUpdated(_tranchIndex, _newState, msg.sender);
+  function _setTrancheState (uint256 _trancheIndex, uint256 _newState) internal {
+    if (dataUint256[__i(_trancheIndex, "state")] != _newState) {
+      dataUint256[__i(_trancheIndex, "state")] = _newState;
+      emit TrancheStateUpdated(_trancheIndex, _newState, msg.sender);
     }
   }
 
@@ -50,7 +50,7 @@ abstract contract PolicyFacetBase is EternalStorage, IPolicyStates, AccessContro
     return IPolicyTreasury(dataAddress["treasury"]);
   }
 
-  function _getNumberOfTranchPaymentsMissed (uint256 _index) internal view returns (uint256) {
+  function _getNumberOfTranchePaymentsMissed (uint256 _index) internal view returns (uint256) {
     uint256 numPremiums = dataUint256[__i(_index, "numPremiums")];
     uint256 numPremiumsPaid = dataUint256[__i(_index, "numPremiumsPaid")];
 
@@ -71,7 +71,7 @@ abstract contract PolicyFacetBase is EternalStorage, IPolicyStates, AccessContro
     }
   }
 
-  function _tranchPaymentsAllMade (uint256 _index) internal view returns (bool) {
+  function _tranchePaymentsAllMade (uint256 _index) internal view returns (bool) {
     uint256 numPremiums = dataUint256[__i(_index, "numPremiums")];
     uint256 numPremiumsPaid = dataUint256[__i(_index, "numPremiumsPaid")];
     return (numPremiumsPaid == numPremiums);

--- a/contracts/TrancheToken.sol
+++ b/contracts/TrancheToken.sol
@@ -3,17 +3,17 @@ pragma solidity 0.6.12;
 
 import './base/IERC20.sol';
 import './base/PlatformToken.sol';
-import './base/IPolicyTranchTokensFacet.sol';
+import './base/IPolicyTrancheTokensFacet.sol';
 
 /**
- * @dev A Policy tranch token.
+ * @dev A Policy tranche token.
  */
-contract TranchToken is IERC20, PlatformToken {
-  IPolicyTranchTokensFacet public impl;
+contract TrancheToken is IERC20, PlatformToken {
+  IPolicyTrancheTokensFacet public impl;
   uint256 public index;
 
   constructor (address _impl, uint256 _index) public {
-    impl = IPolicyTranchTokensFacet(_impl);
+    impl = IPolicyTrancheTokensFacet(_impl);
     index = _index;
   }
 

--- a/contracts/admin.json
+++ b/contracts/admin.json
@@ -941,7 +941,7 @@
       ]
     },
     {
-      "id": "getTranchInfo",
+      "id": "getTrancheInfo",
       "title": "Policy: Get tranche info",
       "inputs": [
         {
@@ -971,24 +971,24 @@
         {
           "type": "call",
           "contract": "IPolicy",
-          "method": "getTranchInfo",
+          "method": "getTrancheInfo",
           "address": "@input[contractAddress]",
           "args": {
             "_index": "@input[index]"
           },
-          "saveResultAsInput": "tranchInfo"
+          "saveResultAsInput": "trancheInfo"
         }
       ],
       "outputs": [
         {
           "title": "Token address",
           "type": "address",
-          "value": "@input[tranchInfo][token_]"
+          "value": "@input[trancheInfo][token_]"
         },
         {
           "title": "State",
           "type": "int",
-          "value": "@input[tranchInfo][state_]",
+          "value": "@input[trancheInfo][state_]",
           "transform": [
             {
               "type": "toMappedString",
@@ -1007,39 +1007,39 @@
           "type": "int",
           "scale": "-18",
           "unit": "Tokens",
-          "value": "@input[tranchInfo][balance_]"
+          "value": "@input[trancheInfo][balance_]"
         },
         {
           "title": "No. of premiums in total",
           "type": "int",
-          "value": "@input[tranchInfo][numPremiums_]"
+          "value": "@input[trancheInfo][numPremiums_]"
         },
         {
           "title": "No. of premiums paid",
           "type": "int",
-          "value": "@input[tranchInfo][numPremiumsPaid_]"
+          "value": "@input[trancheInfo][numPremiumsPaid_]"
         },
         {
           "title": "No. of premiums missed",
           "type": "int",
-          "value": "@input[tranchInfo][premiumPaymentsMissed_]"
+          "value": "@input[trancheInfo][premiumPaymentsMissed_]"
         },
         {
           "title": "Next premium index",
           "type": "int",
-          "value": "@input[tranchInfo][nextPremiumIndex_]"
+          "value": "@input[trancheInfo][nextPremiumIndex_]"
         },
         {
           "title": "Next premium due",
           "type": "int",
           "scale": "-18",
           "unit": "Tokens",
-          "value": "@input[tranchInfo][nextPremiumAmount_]"
+          "value": "@input[trancheInfo][nextPremiumAmount_]"
         },
         {
           "title": "When next premium is due by",
           "type": "string",
-          "value": "@input[tranchInfo][nextPremiumDueAt_]",
+          "value": "@input[trancheInfo][nextPremiumDueAt_]",
           "transform": [
             {
               "type": "intToDateString",
@@ -1050,22 +1050,22 @@
         {
           "title": "Shared sold",
           "type": "int",
-          "value": "@input[tranchInfo][sharesSold_]"
+          "value": "@input[trancheInfo][sharesSold_]"
         },
         {
           "title": "Market offer id for initial sale",
           "type": "int",
-          "value": "@input[tranchInfo][initialSaleOfferId_]"
+          "value": "@input[trancheInfo][initialSaleOfferId_]"
         },
         {
           "title": "Market offer id for buyback",
           "type": "int",
-          "value": "@input[tranchInfo][finalBuybackofferId_]"
+          "value": "@input[trancheInfo][finalBuybackofferId_]"
         }
       ]
     },
     {
-      "id": "getTranchPremiumInfo",
+      "id": "getTranchePremiumInfo",
       "title": "Policy: Get premium info",
       "inputs": [
         {
@@ -1080,7 +1080,7 @@
           ]
         },
         {
-          "name": "tranchIndex",
+          "name": "trancheIndex",
           "title": "Tranche index (0-based)",
           "type": "int",
           "validation": [
@@ -1106,10 +1106,10 @@
         {
           "type": "call",
           "contract": "IPolicy",
-          "method": "getTranchPremiumInfo",
+          "method": "getTranchePremiumInfo",
           "address": "@input[contractAddress]",
           "args": {
-            "_tranchIndex": "@input[tranchIndex]",
+            "_trancheIndex": "@input[trancheIndex]",
             "_premiumIndex": "@input[premiumIndex]"
           },
           "saveResultAsInput": "premiumInfo"
@@ -1170,7 +1170,7 @@
         },
         {
           "name": "index",
-          "title": "Tranch index (0-based)",
+          "title": "Tranche index (0-based)",
           "type": "int",
           "validation": [
             {
@@ -1195,7 +1195,7 @@
         {
           "type": "send",
           "contract": "IPolicy",
-          "method": "payTranchPremium",
+          "method": "payTranchePremium",
           "address": "@input[contractAddress]",
           "args": {
             "_index": "@input[index]",
@@ -1233,7 +1233,7 @@
         },
         {
           "name": "index",
-          "title": "Tranch index (0-based)",
+          "title": "Tranche index (0-based)",
           "type": "int",
           "validation": [
             {
@@ -1258,11 +1258,11 @@
         {
           "type": "send",
           "contract": "IEntity",
-          "method": "payTranchPremium",
+          "method": "payTranchePremium",
           "address": "@input[contractAddress]",
           "args": {
             "_policy": "@input[policyAddress]",
-            "_tranchIndex": "@input[index]",
+            "_trancheIndex": "@input[index]",
             "_amount": "@input[amount]"
           }
         }
@@ -1286,7 +1286,7 @@
         },
         {
           "name": "index",
-          "title": "Tranch index (0-based)",
+          "title": "Tranche index (0-based)",
           "type": "int",
           "validation": [
             {
@@ -1314,7 +1314,7 @@
           "method": "makeClaim",
           "address": "@input[policyAddress]",
           "args": {
-            "_tranchIndex": "@input[index]",
+            "_trancheIndex": "@input[index]",
             "_amount": "@input[amount]"
           }
         }
@@ -1366,9 +1366,9 @@
           "value": "@input[details][amount_]"
         },
         {
-          "title": "Tranch index",
+          "title": "Tranche index",
           "type": "int",
-          "value": "@input[details][tranchIndex_]"
+          "value": "@input[details][trancheIndex_]"
         },
         {
           "title": "State",

--- a/contracts/base/IEntityCoreFacet.sol
+++ b/contracts/base/IEntityCoreFacet.sol
@@ -32,7 +32,7 @@ interface IEntityCoreFacet {
    *
    * `_trancheData`
    *    * This parameter is structured as follows. The outer array represents the list of tranches. The 
-   *      inner array represents the `[ number of tranch shares, price per share, ...premium payment amounts ]`.
+   *      inner array represents the `[ number of tranche shares, price per share, ...premium payment amounts ]`.
    *
    * @param _id Unique id that represents the policy - this is what stakeholder will sign to approve the policy.
    * @param _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP See above.
@@ -49,13 +49,13 @@ interface IEntityCoreFacet {
   ) external;
 
   /**
-   * @dev Pay the next expected premium for a tranch using the assets owned by this entity.
+   * @dev Pay the next expected premium for a tranche using the assets owned by this entity.
    *
-   * @param _policy Policy which owns the tranch.
-   * @param _tranchIndex Index of the tranch in the policy.
+   * @param _policy Policy which owns the tranche.
+   * @param _trancheIndex Index of the tranche in the policy.
    * @param _amount Amount of premium to pay.
    */
-  function payTranchPremium(address _policy, uint256 _tranchIndex, uint256 _amount) external;
+  function payTranchePremium(address _policy, uint256 _trancheIndex, uint256 _amount) external;
 
   /**
    * @dev Emitted when a new policy has been created.

--- a/contracts/base/IMarketObserverDataTypes.sol
+++ b/contracts/base/IMarketObserverDataTypes.sol
@@ -6,13 +6,13 @@ pragma solidity 0.6.12;
  */
 abstract contract IMarketObserverDataTypes {
   /**
-   * @dev Tranch token initial sale
+   * @dev Tranche token initial sale
    */
-  uint256 constant public MODT_TRANCH_SALE = 1;
+  uint256 constant public MODT_TRANCHE_SALE = 1;
   /**
-   * @dev Tranch token buyback
+   * @dev Tranche token buyback
    */
-  uint256 constant public MODT_TRANCH_BUYBACK = 2;
+  uint256 constant public MODT_TRANCHE_BUYBACK = 2;
   /**
    * @dev Entity token sale
    */

--- a/contracts/base/IPolicy.sol
+++ b/contracts/base/IPolicy.sol
@@ -10,7 +10,7 @@ import "./IPolicyClaimsFacet.sol";
 import "./IChild.sol";
 import "./IPolicyCommissionsFacet.sol";
 import "./IPolicyPremiumsFacet.sol";
-import "./IPolicyTranchTokensFacet.sol";
+import "./IPolicyTrancheTokensFacet.sol";
 import "./IPolicyApprovalsFacet.sol";
 import "./IPolicyStates.sol";
 
@@ -27,6 +27,6 @@ abstract contract IPolicy is
   IPolicyClaimsFacet,
   IPolicyCommissionsFacet,
   IPolicyPremiumsFacet,
-  IPolicyTranchTokensFacet,
+  IPolicyTrancheTokensFacet,
   IPolicyApprovalsFacet
   {}

--- a/contracts/base/IPolicyClaimsFacet.sol
+++ b/contracts/base/IPolicyClaimsFacet.sol
@@ -25,10 +25,10 @@ abstract contract IPolicyClaimsFacet {
   /**
    * @dev Make a claim.
    *
-   * @param _tranchIndex Tranch index.
+   * @param _trancheIndex Tranche index.
    * @param _amount Amount claimed.
    */
-  function makeClaim (uint256 _tranchIndex, uint256 _amount) virtual external;
+  function makeClaim (uint256 _trancheIndex, uint256 _amount) virtual external;
   /**
    * @dev Approve a claim.
    *
@@ -72,12 +72,12 @@ abstract contract IPolicyClaimsFacet {
    * @dev Get claim info.
    *
    * @return amount_ Amount the claim is for.
-   * @return tranchIndex_ Tranch the claim is against.
+   * @return trancheIndex_ Tranche the claim is against.
    * @return state_ Claim state.
    */
   function getClaimInfo (uint256 _claimIndex) virtual public view returns (
     uint256 amount_,
-    uint256 tranchIndex_,
+    uint256 trancheIndex_,
     uint256 state_,
     bool disputed_,
     bool acknowledged_
@@ -90,11 +90,11 @@ abstract contract IPolicyClaimsFacet {
   /**
    * @dev Emitted when a new claim has been created.
    *
-   * @param tranchIndex The tranch index.
+   * @param trancheIndex The tranche index.
    * @param claimIndex The claim index.
    * @param caller The claim maker.
    */
-  event NewClaim(uint256 indexed tranchIndex, uint256 indexed claimIndex, address indexed caller);
+  event NewClaim(uint256 indexed trancheIndex, uint256 indexed claimIndex, address indexed caller);
   /**
    * @dev Emitted when a claim has been disputed.
    *

--- a/contracts/base/IPolicyCoreFacet.sol
+++ b/contracts/base/IPolicyCoreFacet.sol
@@ -7,13 +7,13 @@ pragma solidity 0.6.12;
  */
 interface IPolicyCoreFacet {
   /**
-   * @dev Create tranch.
+   * @dev Create tranche.
    *
-   * @param _numShares No. of shares in this tranch.
+   * @param _numShares No. of shares in this tranche.
    * @param _pricePerShareAmount Price of each share during the initial sale period.
    * @param _premiums Premium payment amounts in chronological order.
    */
-  function createTranch (
+  function createTranche (
     uint256 _numShares,
     uint256 _pricePerShareAmount,
     uint256[] calldata _premiums
@@ -27,12 +27,12 @@ interface IPolicyCoreFacet {
    * @return initiationDate_ Initiation date  (seconds since epoch).
    * @return startDate_ Start date  (seconds since epoch).
    * @return maturationDate_ Maturation date (seconds since epoch).
-   * @return unit_ Payment unit (for tranch sale, premiums, claim payouts, etc).
-   * @return premiumIntervalSeconds_ Time between premium payments (seconds).
+   * @return unit_ Payment unit (for tranche sale, premiums, claim payouts, etc).
    * @return numTranches_ No. of tranches created.
    * @return state_ Current policy state.
    * @return type_ Policy type.
    */
+  //  * @return premiumIntervalSeconds_ Time between premium payments (seconds).
   function getInfo () external view returns (
     bytes32 id_,
     address treasury_,
@@ -40,27 +40,27 @@ interface IPolicyCoreFacet {
     uint256 startDate_,
     uint256 maturationDate_,
     address unit_,
-    uint256 premiumIntervalSeconds_,
+    // uint256 premiumIntervalSeconds_,
     uint256 numTranches_,
     uint256 state_,
     uint256 type_
   );
 
   /**
-   * @dev Get tranch info.
+   * @dev Get tranche info.
    *
-   * @param _index Tranch index.
-   * @return token_ Tranch ERC-20 token address.
-   * @return state_ Current tranch state.
+   * @param _index Tranche index.
+   * @return token_ Tranche ERC-20 token address.
+   * @return state_ Current tranche state.
    * @return numShares_ No. of shares.
    * @return initialPricePerShare_ Initial price per share.
-   * @return balance_ Current tranch balance (of the payment unit)
+   * @return balance_ Current tranche balance (of the payment unit)
    * @return sharesSold_ No. of shared sold (during the initial sale period).
    * @return initialSaleOfferId_ Market offer id of the initial sale.
    * @return finalBuybackofferId_ Market offer id of the post-maturation/cancellation token buyback.
    * @return buybackCompleted_ True once token buyback has completed.
    */
-  function getTranchInfo (uint256 _index) external view returns (
+  function getTrancheInfo (uint256 _index) external view returns (
     address token_,
     uint256 state_,
     uint256 numShares_,
@@ -74,12 +74,13 @@ interface IPolicyCoreFacet {
 
 
 
-  /**
-   * @dev Get the max. no. of premium payments possible based on the policy dates.
-   *
-   * @return Max. no. of premium payments possible.
-   */
-  function calculateMaxNumOfPremiums() external view returns (uint256);
+  // /**
+  //  * @dev Get the max. no. of premium payments possible based on the policy dates.
+  //  *
+  //  * @return Max. no. of premium payments possible.
+  //  */
+  // function calculateMaxNumOfPremiums() external view returns (uint256);
+
   /**
    * @dev Get whether the initiation date has passed.
    *
@@ -100,17 +101,17 @@ interface IPolicyCoreFacet {
   function maturationDateHasPassed () external view returns (bool);
 
   /**
-   * @dev Heartbeat: Ensure the policy and tranch states are up-to-date.
+   * @dev Heartbeat: Ensure the policy and tranche states are up-to-date.
    */
   function checkAndUpdateState () external;
 
   // events
 
   /**
-   * @dev Emitted when a new tranch has been created.
-   * @param index The tranch index.
+   * @dev Emitted when a new tranche has been created.
+   * @param index The tranche index.
    */
-  event CreateTranch(
+  event CreateTranche(
     uint256 index
   );
 }

--- a/contracts/base/IPolicyPremiumsFacet.sol
+++ b/contracts/base/IPolicyPremiumsFacet.sol
@@ -6,19 +6,19 @@ pragma solidity 0.6.12;
  */
 interface IPolicyPremiumsFacet {
   /**
-   * @dev Pay the next expected premium for the given tranch.
+   * @dev Pay the next expected premium for the given tranche.
    *
    * The caller should ensure they have approved the policy to transfer tokens on their behalf.
    *
-   * @param _index Tranch index.
+   * @param _index Tranche index.
    * @param _amount The amount to pay.
    */
-  function payTranchPremium (uint256 _index, uint256 _amount) external;
+  function payTranchePremium (uint256 _index, uint256 _amount) external;
 
   /**
-   * @dev Get tranch premiums info.
+   * @dev Get tranche premiums info.
    *
-   * @param _tranchIndex Tranch index.
+   * @param _trancheIndex Tranche index.
    * @return numPremiums_ No. of premium payments required in total.
    * @return nextPremiumAmount_ Payment due by the next premium interval.
    * @return nextPremiumDueAt_ When the next premium payment is due by (timestamp = seconds since epoch).
@@ -26,7 +26,7 @@ interface IPolicyPremiumsFacet {
    * @return premiumPaymentsMissed_ No. of premium payments that have been missed.
    * @return numPremiumsPaid_ No. of premium payments made.
    */
-  function getTranchPremiumsInfo (uint256 _tranchIndex) external view returns (
+  function getTranchePremiumsInfo (uint256 _trancheIndex) external view returns (
     uint256 numPremiums_,
     uint256 nextPremiumAmount_,
     uint256 nextPremiumDueAt_,
@@ -36,16 +36,16 @@ interface IPolicyPremiumsFacet {
   );
 
   /**
-   * @dev Get tranch specific premium info.
+   * @dev Get tranche specific premium info.
    *
-   * @param _tranchIndex Tranch index.
+   * @param _trancheIndex Tranche index.
    * @param _premiumIndex Premium index.
    * @return amount_ Amount due.
    * @return dueAt_ When it is due by (timestamp = seconds since epoch).
    * @return paidSoFar_ How much has been paid so far.
    * @return fullyPaidAt_ When it was fully paid (timestamp = seconds since epoch).
    */
-  function getTranchPremiumInfo (uint256 _tranchIndex, uint256 _premiumIndex) external view returns (
+  function getTranchePremiumInfo (uint256 _trancheIndex, uint256 _premiumIndex) external view returns (
     uint256 amount_,
     uint256 dueAt_,
     uint256 paidSoFar_,
@@ -56,9 +56,9 @@ interface IPolicyPremiumsFacet {
 
   /**
    * @dev Emitted when a premium payment has been made.
-   * @param tranchIndex The tranch token address.
+   * @param trancheIndex The tranche token address.
    * @param amount The amount paid.
    * @param caller The payer.
    */
-  event PremiumPayment (uint256 indexed tranchIndex, uint256 indexed amount, address indexed caller);
+  event PremiumPayment (uint256 indexed trancheIndex, uint256 indexed amount, address indexed caller);
 }

--- a/contracts/base/IPolicyStates.sol
+++ b/contracts/base/IPolicyStates.sol
@@ -43,28 +43,28 @@ abstract contract IPolicyStates {
   uint256 constant public POLICY_STATE_CANCELLED = 4;
 
   /**
-   * @dev State: The tranch has just been created.
+   * @dev State: The tranche has just been created.
    */
-  uint256 constant public TRANCH_STATE_CREATED = 0;
+  uint256 constant public TRANCHE_STATE_CREATED = 0;
   /**
-   * @dev State: The tranch initial sale is in progress.
+   * @dev State: The tranche initial sale is in progress.
    */
-  uint256 constant public TRANCH_STATE_SELLING = 1;
+  uint256 constant public TRANCHE_STATE_SELLING = 1;
   /**
-   * @dev State: The tranch initial sale has completed it is now active.
+   * @dev State: The tranche initial sale has completed it is now active.
    */
-  uint256 constant public TRANCH_STATE_ACTIVE = 2;
+  uint256 constant public TRANCHE_STATE_ACTIVE = 2;
   /**
-   * @dev State: The tranch has matured.
+   * @dev State: The tranche has matured.
    */
-  uint256 constant public TRANCH_STATE_MATURED = 3;
+  uint256 constant public TRANCHE_STATE_MATURED = 3;
   /**
-   * @dev State: The tranch has been cancelled.
+   * @dev State: The tranche has been cancelled.
    */
-  uint256 constant public TRANCH_STATE_CANCELLED = 4;
+  uint256 constant public TRANCHE_STATE_CANCELLED = 4;
 
   // events
 
   event PolicyStateUpdated (uint256 indexed state, address indexed caller);
-  event TranchStateUpdated (uint256 indexed tranchIndex, uint256 indexed state, address indexed caller);
+  event TrancheStateUpdated (uint256 indexed trancheIndex, uint256 indexed state, address indexed caller);
 }

--- a/contracts/base/IPolicyTrancheTokensFacet.sol
+++ b/contracts/base/IPolicyTrancheTokensFacet.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.6.12;
 
 /**
- * @dev Tranch token helpers
+ * @dev Tranche token helpers
  */
-interface IPolicyTranchTokensFacet {
+interface IPolicyTrancheTokensFacet {
   // ERC-20 queries
   function tknName(uint256 _index) external view returns (string memory);
   function tknSymbol(uint256 _index) external view returns (string memory);

--- a/contracts/base/IPolicyTypes.sol
+++ b/contracts/base/IPolicyTypes.sol
@@ -6,11 +6,11 @@ pragma solidity 0.6.12;
  */
 abstract contract IPolicyTypes {
   /**
-   * @dev SPV-based policy that has tranch tokens.
+   * @dev SPV-based policy that has tranche tokens.
    */
   uint256 constant public POLICY_TYPE_SPV = 0;
   /**
-   * @dev Policy is part of an underwriter's portfolio and does not issue tranch tokens.
+   * @dev Policy is part of an underwriter's portfolio and does not issue tranche tokens.
    */
   uint256 constant public POLICY_TYPE_PORTFOLIO = 1;
 }

--- a/contracts/test/DummyEntityFacet.sol
+++ b/contracts/test/DummyEntityFacet.sol
@@ -19,7 +19,7 @@ contract DummyEntityFacet is IDiamondFacet, IEntityCoreFacet, IEntityFundingFace
 
   function createPolicy(
     bytes32 _id,
-    uint256[] calldata _typeAndPremiumIntervalSecondsAndDatesAndCommissionsBP,
+    uint256[] calldata _typeAndDatesAndCommissionsBP,
     address[] calldata _unitAndTreasuryAndStakeholders,
     uint256[][] calldata _trancheData,
     bytes[] calldata _approvalSignatures
@@ -27,7 +27,7 @@ contract DummyEntityFacet is IDiamondFacet, IEntityCoreFacet, IEntityFundingFace
 
   function deposit(address _unit, uint256 _amount) external override {}
   function withdraw(address _unit, uint256 _amount) external override {}
-  function payTranchPremium(address _policy, uint256 _tranchIndex, uint256 _amount) external override {}
+  function payTranchePremium(address _policy, uint256 _trancheIndex, uint256 _amount) external override {}
   function trade(address _payUnit, uint256 _payAmount, address _buyUnit, uint256 _buyAmount) external override returns (uint256) {}
   function sellAtBestPrice(address _sellUnit, uint256 _sellAmount, address _buyUnit) external override {}
 }

--- a/contracts/test/DummyPolicyFacet.sol
+++ b/contracts/test/DummyPolicyFacet.sol
@@ -7,11 +7,13 @@ import '../base/IPolicyCoreFacet.sol';
 contract DummyPolicyFacet is IDiamondFacet, IPolicyCoreFacet {
   function getSelectors () public pure override returns (bytes memory) {
     return abi.encodePacked(
-      IPolicyCoreFacet.calculateMaxNumOfPremiums.selector
+      //Todo: why only this function here?
+      // IPolicyCoreFacet.calculateMaxNumOfPremiums.selector
+      IPolicyCoreFacet.getInfo.selector
     );
   }
 
-  function createTranch (
+  function createTranche (
     uint256 _numShares,
     uint256 _pricePerShareAmount,
     uint256[] calldata _premiums
@@ -24,13 +26,13 @@ contract DummyPolicyFacet is IDiamondFacet, IPolicyCoreFacet {
     uint256 startDate_,
     uint256 maturationDate_,
     address unit_,
-    uint256 premiumIntervalSeconds_,
+    // uint256 premiumIntervalSeconds_,
     uint256 numTranches_,
     uint256 state_,
     uint256 type_
   ) {}
 
-  function getTranchInfo (uint256 _index) external view override returns (
+  function getTrancheInfo (uint256 _index) external view override returns (
     address token_,
     uint256 state_,
     uint256 numShares_,
@@ -44,9 +46,9 @@ contract DummyPolicyFacet is IDiamondFacet, IPolicyCoreFacet {
 
   function checkAndUpdateState () external override {}
 
-  function calculateMaxNumOfPremiums() external view override returns (uint256) {
-    return 666;
-  }
+  // function calculateMaxNumOfPremiums() external view override returns (uint256) {
+  //   return 666;
+  // }
 
   function initiationDateHasPassed () external view override returns (bool) {
     return false;

--- a/deploy/modules/policyImplementations.js
+++ b/deploy/modules/policyImplementations.js
@@ -14,7 +14,7 @@ export const ensurePolicyImplementationsAreDeployed = async (ctx = {}) => {
       'PolicyClaimsFacet',
       'PolicyCommissionsFacet',
       'PolicyPremiumsFacet',
-      'PolicyTranchTokensFacet',
+      'PolicyTrancheTokensFacet',
       'PolicyApprovalsFacet',
     ].concat(extraFacets),
     facetListSettingsKey: SETTINGS.POLICY_IMPL,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,7 +110,7 @@ The four main types of entities are: _Capital providers, brokers, insured partie
 
 Every policy operates according to the following timeline:
 
-1. **Initiation date** - _The point in time when the policy's tranch tokens will go up for an initial sale._
+1. **Initiation date** - _The point in time when the policy's tranche tokens will go up for an initial sale._
 2. **Start date** - _The point in time after the initiation date when the policy's sale should have been completed by, and after which the policy is considered active._
 3. **Maturation date** - _The point in time after the start date when the policy stops being active and stop accepting new claims._
 
@@ -119,13 +119,13 @@ Policies transition between the following [states](https://github.com/nayms/cont
 1. **Created** - _The policy has been created. Tranches can now be created._
 2. **Ready for approval** - _All tranches have been created. The policy must now be approved by all its nominated entities._
 3. **In approval** - _The approval process is underway._
-4. **Approved** - _The policy has been approved by all its nominated entities. Once the initiation date has passed the initial tranch sale can begin._
+4. **Approved** - _The policy has been approved by all its nominated entities. Once the initiation date has passed the initial tranche sale can begin._
 5. **Initiated** - _The policy initial sale is now in progress, whereby all tranches have been put up for sale in order for the policy to be become collateralized._
-6. **Active** - _The start date has passed and the initial sale has completed successfully (i.e. at least one tranch has fully sold out). The policy is now active and will accept claims._
+6. **Active** - _The start date has passed and the initial sale has completed successfully (i.e. at least one tranche has fully sold out). The policy is now active and will accept claims._
 7. **Matured** - _The maturation date has passed and the policy is now longer active. New claims are now longer accepted._
-8. **Buyback** - _All claims have been paid out and the policy is now buying back its tranch tokens from the initial sale using its leftover collateral._
+8. **Buyback** - _All claims have been paid out and the policy is now buying back its tranche tokens from the initial sale using its leftover collateral._
 9. **Closed** - _The buyback has completed and the policy is now fully closed._
-10. **Cancelled** - _The policy has been cancelled. This state is reached if the initial tranch sale fails or if a premium payment is missed._
+10. **Cancelled** - _The policy has been cancelled. This state is reached if the initial tranche sale fails or if a premium payment is missed._
 
 Except for the **Ready for approval** state, all other states are transitioned to via our heartbeat mechanism.
 
@@ -136,35 +136,35 @@ Except for the **Ready for approval** state, all other states are transitioned t
 
 The [`checkAndUpdateState()`](https://github.com/nayms/contracts/blob/master/contracts/base/IPolicyCoreFacet.sol#L109) function is responsible for checking the current state of a policy and progressing it to the next state if necessary. It roughly does the following:
 
-* If the initiation date has passed then begin the initial tranch sale.
-* If the start date has passed then check to see if the tranch sale succeeded and that premium payments are up-to-date. If so then mark the policy as **Active**. If not then mark the policy as **Cancelled**.
+* If the initiation date has passed then begin the initial tranche sale.
+* If the start date has passed then check to see if the tranche sale succeeded and that premium payments are up-to-date. If so then mark the policy as **Active**. If not then mark the policy as **Cancelled**.
 * If the maturation date has passed then mark the policy as **Matured**.
-* If the policy has matured and all claims have been dealt with then initiate the tranch token **Buyback**.
+* If the policy has matured and all claims have been dealt with then initiate the tranche token **Buyback**.
 * Check that premium payments are up-to-date. If not then mark the policy as **Cancelled**.
 
 The heartbeat is currently called automatically by our backend.
 
 ### Tranches
 
-Every policy can have one or more tranches created. Each tranch has a configurable fixed no. of "shares" (similar to equity) as well as an initial price-per-share for during the initial sale period. All tranches are priced in the same currency as the policy.
+Every policy can have one or more tranches created. Each tranche has a configurable fixed no. of "shares" (similar to equity) as well as an initial price-per-share for during the initial sale period. All tranches are priced in the same currency as the policy.
 
 Tranches, like their parent policies, also have states:
 
-* **Created** - _Tranch created._
-* **Selling** - _Tranch tokens have been put for sale as part of the initial sale triggered by the policy initiation date._
-* **Active** - _All tranch tokens sold out by the policy start date, and the tranch is thus active. Only tranches in this state can have claims made against them._
-* **Matured** - _Policy has matured, and the tranch has thus matured._
-* **Cancelled** - _The tranch tokens did not fully sell out by the policy start date, and thus the tranch is cancelled._
+* **Created** - _Tranche created._
+* **Selling** - _Tranche tokens have been put for sale as part of the initial sale triggered by the policy initiation date._
+* **Active** - _All tranche tokens sold out by the policy start date, and the tranche is thus active. Only tranches in this state can have claims made against them._
+* **Matured** - _Policy has matured, and the tranche has thus matured._
+* **Cancelled** - _The tranche tokens did not fully sell out by the policy start date, and thus the tranche is cancelled._
 
-Tranche shares are [represented as ERC-20 tokens](https://github.com/nayms/contracts/blob/master/contracts/TranchToken.sol), meaning that each each tranch gets its own ERC-20 token. Since we want to restrict access to these tranch tokens to authorized entities they can only be [transferred through our Matching market](https://github.com/nayms/contracts/blob/master/contracts/PolicyTranchTokens.sol#L74).
+Tranche shares are [represented as ERC-20 tokens](https://github.com/nayms/contracts/blob/master/contracts/TrancheToken.sol), meaning that each each tranche gets its own ERC-20 token. Since we want to restrict access to these tranche tokens to authorized entities they can only be [transferred through our Matching market](https://github.com/nayms/contracts/blob/master/contracts/PolicyTrancheTokens.sol#L74).
 
-The Tranch token logic is actually implemented within the policy, thus allowing us to upgrade tranch token code when upgrading policy code:
+The Tranche token logic is actually implemented within the policy, thus allowing us to upgrade tranche token code when upgrading policy code:
 
 ![token](https://user-images.githubusercontent.com/266594/118975104-8a6d7300-b96b-11eb-88f7-e883c34a155d.png)
 
 ### Claims
 
-Claims can be made representatives of insured parties against a specific active policy tranch. Claims go through the following state transitions:
+Claims can be made representatives of insured parties against a specific active policy tranche. Claims go through the following state transitions:
 
 1. **Created** - _A claim has been created._
 2. **Approved** - _A claim has been approved the claims administrator_.
@@ -181,7 +181,7 @@ At present there is no deadline for approving or declining claims. This also mea
 
 Every policy has an associated [treasury](#treasury) which stores all its funds. The treasury is usually the capital provider entity associated with the policy.
 
-Initially, all tranch tokens are owned by the treasury. This means the initial token sale is coordinated between the treasury and the [matching market](#matching-market) on behalf of the policy. And the collateral obtained as a result of the purchase is also then automatically help in the treasury. 
+Initially, all tranche tokens are owned by the treasury. This means the initial token sale is coordinated between the treasury and the [matching market](#matching-market) on behalf of the policy. And the collateral obtained as a result of the purchase is also then automatically help in the treasury. 
 
 Premium payments are forward to the treasury, minus [commision](#commissions) payments.
 
@@ -191,7 +191,7 @@ Commission payments for the various associated entities are taken out of incomin
 
 ## Matching market
 
-We use an unmodified fork of the [Maker OTC matching market](https://github.com/nayms/maker-otc) to facilitate tranch token sales and trades. In fact, at present the tranch tokens can only be transferred by our on-chain market, though we will likely loosen this restriction later.
+We use an unmodified fork of the [Maker OTC matching market](https://github.com/nayms/maker-otc) to facilitate tranche token sales and trades. In fact, at present the tranche tokens can only be transferred by our on-chain market, though we will likely loosen this restriction later.
 
 
 ## Deployments

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nayms/contracts",
-  "version": "1.0.0-local.1637670508474",
+  "version": "1.0.0-local.1637832747874",
   "description": "Nayms smart contracts",
   "main": "index.js",
   "publishConfig": {

--- a/test/entity.js
+++ b/test/entity.js
@@ -5,7 +5,7 @@ import {
   BYTES32_ZERO,
   createEntity,
   createPolicy,
-  createTranch,
+  createTranche,
 } from './utils'
 
 import { events } from '../'
@@ -938,7 +938,7 @@ describe('Entity', () => {
       await acl.hasRole(policyContext, entityRep, ROLES.POLICY_OWNER).should.eventually.eq(HAS_ROLE_CONTEXT)
     })
 
-    describe('and policy tranch premiums can be paid', () => {
+    describe('and policy tranche premiums can be paid', () => {
       let policyOwner
       let policy
       let policyContext
@@ -963,32 +963,33 @@ describe('Entity', () => {
         const accessControl = await AccessControl.at(policy.address)
         policyContext = await accessControl.aclContext()
 
-        await createTranch(policy, { 
+        await createTranche(policy, { 
           numShares: 1,
           pricePerShareAmount: 1,
-          premiums: [premiumAmount],
+          // premiums: [premiumAmount],
+          premiumsDiff: [0, premiumAmount],
         }, { from: policyOwner })
       })
 
       it('but not by anyone', async () => {
-        await entity.payTranchPremium(policy.address, 0, premiumAmount, { from: accounts[8] }).should.be.rejectedWith('must be entity rep')
+        await entity.payTranchePremium(policy.address, 0, premiumAmount, { from: accounts[8] }).should.be.rejectedWith('must be entity rep')
       })
 
       it('but not by entity rep if we do not have enough tokens to pay with', async () => {
-        await entity.payTranchPremium(policy.address, 0, premiumAmount, { from: entityRep }).should.be.rejectedWith('exceeds entity balance')
+        await entity.payTranchePremium(policy.address, 0, premiumAmount, { from: entityRep }).should.be.rejectedWith('exceeds entity balance')
       })
 
       it('by entity rep if we have enough tokens to pay with', async () => {
         await etherToken.deposit({ value: premiumAmount })
         await etherToken.approve(entity.address, premiumAmount)
         await entity.deposit(etherToken.address, premiumAmount)
-        await entity.payTranchPremium(policy.address, 0, premiumAmount, { from: entityRep }).should.be.fulfilled
+        await entity.payTranchePremium(policy.address, 0, premiumAmount, { from: entityRep }).should.be.fulfilled
       })
 
       it('by entity rep if we have enough tokens to pay with, excluding tokens directly sent to entity', async () => {
         await etherToken.deposit({ value: premiumAmount })
         await etherToken.transfer(entity.address, premiumAmount)
-        await entity.payTranchPremium(policy.address, 0, premiumAmount, { from: entityRep }).should.be.rejectedWith('exceeds entity balance')
+        await entity.payTranchePremium(policy.address, 0, premiumAmount, { from: entityRep }).should.be.rejectedWith('exceeds entity balance')
       })
     })
   })

--- a/test/integrationSPV.js
+++ b/test/integrationSPV.js
@@ -1,7 +1,7 @@
 import {
   extractEventArgs,
   parseEvents,
-  createTranch,
+  createTranche,
   createPolicy,
   createEntity,
   doPolicyApproval,
@@ -83,16 +83,16 @@ describe('Integration: SPV', () => {
   let POLICY_STATE_BUYBACK
   let POLICY_STATE_CLOSED
   
-  let TRANCH_STATE_CREATED
-  let TRANCH_STATE_SELLING
-  let TRANCH_STATE_ACTIVE
-  let TRANCH_STATE_MATURED
-  let TRANCH_STATE_CANCELLED
+  let TRANCHE_STATE_CREATED
+  let TRANCHE_STATE_SELLING
+  let TRANCHE_STATE_ACTIVE
+  let TRANCHE_STATE_MATURED
+  let TRANCHE_STATE_CANCELLED
 
   let FEE_SCHEDULE_STANDARD
   let FEE_SCHEDULE_PLATFORM_ACTION
 
-  let getTranchToken
+  let getTrancheToken
   let approvePolicy
 
   let evmClock
@@ -182,20 +182,22 @@ describe('Integration: SPV', () => {
     market = await ensureMarketIsDeployed({ artifacts, settings })
 
     // setup two tranches
-    await createTranch(policy, {
+    await createTranche(policy, {
       numShares: 100,
       pricePerShareAmount: 2,
-      premiums: [1000, 2000, 3000, 4000, 5000, 6000, 7000],
+      // premiums: [1000, 2000, 3000, 4000, 5000, 6000, 7000],
+      premiumsDiff: [0, 1000 ,500 , 2000, 1000, 3000, 1500, 4000, 2000, 5000, 2500, 6000, 3000, 7000 ]
     }, { from: policyOwnerAddress })
 
-    await createTranch(policy, {
+    await createTranche(policy, {
       numShares: 50,
       pricePerShareAmount: 2,
-      premiums: [1000, 2000, 3000, 4000, 5000, 6000, 7000],
+      // premiums: [1000, 2000, 3000, 4000, 5000, 6000, 7000],
+      premiumsDiff: [0, 1000 ,500 , 2000, 1000, 3000, 1500, 4000, 2000, 5000, 2500, 6000, 3000, 7000 ]
     }, { from: policyOwnerAddress })
 
-    getTranchToken = async idx => {
-      const { token_: tt } = await policy.getTranchInfo(idx)
+    getTrancheToken = async idx => {
+      const { token_: tt } = await policy.getTrancheInfo(idx)
       return await IERC20.at(tt)
     }
 
@@ -216,11 +218,11 @@ describe('Integration: SPV', () => {
     POLICY_STATE_BUYBACK = await policyStates.POLICY_STATE_BUYBACK()
     POLICY_STATE_CLOSED = await policyStates.POLICY_STATE_CLOSED()
 
-    TRANCH_STATE_CREATED = await policyStates.TRANCH_STATE_CREATED()
-    TRANCH_STATE_SELLING = await policyStates.TRANCH_STATE_SELLING()
-    TRANCH_STATE_ACTIVE = await policyStates.TRANCH_STATE_ACTIVE()
-    TRANCH_STATE_MATURED = await policyStates.TRANCH_STATE_MATURED()
-    TRANCH_STATE_CANCELLED = await policyStates.TRANCH_STATE_CANCELLED()
+    TRANCHE_STATE_CREATED = await policyStates.TRANCHE_STATE_CREATED()
+    TRANCHE_STATE_SELLING = await policyStates.TRANCHE_STATE_SELLING()
+    TRANCHE_STATE_ACTIVE = await policyStates.TRANCHE_STATE_ACTIVE()
+    TRANCHE_STATE_MATURED = await policyStates.TRANCHE_STATE_MATURED()
+    TRANCHE_STATE_CANCELLED = await policyStates.TRANCHE_STATE_CANCELLED()
 
     const { facets: [marketCoreAddress] } = market
     const mktFeeSchedules = await IMarketFeeSchedules.at(marketCoreAddress)
@@ -256,65 +258,65 @@ describe('Integration: SPV', () => {
           await approvePolicy()
         })
 
-        it('but not if tranch premiums have not been paid', async () => {
+        it('but not if tranche premiums have not been paid', async () => {
           await etherToken.deposit({ value: 100000 })
           await etherToken.approve(policy.address, 100000)
 
           // pay all tranches except the second one
-          await policy.payTranchPremium(0, 1000)
-          await policy.payTranchPremium(2, 1000)
+          await policy.payTranchePremium(0, 1000)
+          await policy.payTranchePremium(2, 1000)
 
           await evmClock.setAbsoluteTime(initiationDate)
 
           await policy.checkAndUpdateState().should.be.fulfilled
-          await policy.getTranchInfo(0).should.eventually.matchObj({
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
             initialSaleOfferId_: 0,
           })
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_APPROVED })
         })
 
-        describe('once tranch premiums are up-to-date', () => {
+        describe('once tranche premiums are up-to-date', () => {
           beforeEach(async () => {
             await etherToken.deposit({ value: 100000 })
             await etherToken.approve(policy.address, 100000)
-            await policy.payTranchPremium(0, 1000)
-            await policy.payTranchPremium(1, 1000)
+            await policy.payTranchePremium(0, 1000)
+            await policy.payTranchePremium(1, 1000)
             await evmClock.setAbsoluteTime(initiationDate)
           })
 
           it('and then tranches get put on the market', async () => {
             // check order ids are not yet set
-            await policy.getTranchInfo(0).should.eventually.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.matchObj({
               initialSaleOfferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.matchObj({
               initialSaleOfferId_: 0,
             })
 
-            const tranchTokens = await Promise.all([getTranchToken(0), getTranchToken(1)])
+            const trancheTokens = await Promise.all([getTrancheToken(0), getTrancheToken(1)])
 
-            await tranchTokens[0].balanceOf(market.address).should.eventually.eq(0)
-            await tranchTokens[1].balanceOf(market.address).should.eventually.eq(0)
+            await trancheTokens[0].balanceOf(market.address).should.eventually.eq(0)
+            await trancheTokens[1].balanceOf(market.address).should.eventually.eq(0)
 
-            await tranchTokens[0].balanceOf(entity.address).should.eventually.eq(100)
-            await tranchTokens[1].balanceOf(entity.address).should.eventually.eq(50)
+            await trancheTokens[0].balanceOf(entity.address).should.eventually.eq(100)
+            await trancheTokens[1].balanceOf(entity.address).should.eventually.eq(50)
 
             const result = await policy.checkAndUpdateState()
 
             const ev = extractEventArgs(result, events.PolicyStateUpdated)
             expect(ev.state).to.eq(POLICY_STATE_INITIATED.toString())
 
-            await tranchTokens[0].balanceOf(market.address).should.eventually.eq(100)
-            await tranchTokens[1].balanceOf(market.address).should.eventually.eq(50)
+            await trancheTokens[0].balanceOf(market.address).should.eventually.eq(100)
+            await trancheTokens[1].balanceOf(market.address).should.eventually.eq(50)
 
-            await tranchTokens[0].balanceOf(entity.address).should.eventually.eq(0)
-            await tranchTokens[1].balanceOf(entity.address).should.eventually.eq(0)
+            await trancheTokens[0].balanceOf(entity.address).should.eventually.eq(0)
+            await trancheTokens[1].balanceOf(entity.address).should.eventually.eq(0)
 
             // check order ids are set
-            await policy.getTranchInfo(0).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.not.matchObj({
               initialSaleOfferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.not.matchObj({
               initialSaleOfferId_: 0,
             })
           })
@@ -322,7 +324,7 @@ describe('Integration: SPV', () => {
           it('and the market offer uses the "platform action" fee schedule', async () => {
             await policy.checkAndUpdateState()
             
-            const { initialSaleOfferId_: marketOfferId } = await policy.getTranchInfo(0)
+            const { initialSaleOfferId_: marketOfferId } = await policy.getTrancheInfo(0)
 
             await market.getOffer(marketOfferId).should.eventually.matchObj({
               feeSchedule_: FEE_SCHEDULE_PLATFORM_ACTION,
@@ -334,12 +336,12 @@ describe('Integration: SPV', () => {
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_INITIATED })
           })
 
-          it('and then tranch states get updated', async () => {
+          it('and then tranche states get updated', async () => {
             await policy.checkAndUpdateState()
-            await policy.getTranchInfo(0).should.eventually.matchObj({
-              state_: TRANCH_STATE_SELLING,
+            await policy.getTrancheInfo(0).should.eventually.matchObj({
+              state_: TRANCHE_STATE_SELLING,
             })
-            await policy.getTranchInfo(1).should.eventually.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.matchObj({
               sharesSold_: 0,
             })
           })
@@ -353,7 +355,7 @@ describe('Integration: SPV', () => {
   })
 
   describe('once tranches begins selling', () => {
-    let tranchToken
+    let trancheToken
     let marketOfferId
 
     beforeEach(async () => {
@@ -361,8 +363,8 @@ describe('Integration: SPV', () => {
 
       await etherToken.deposit({ value: 100000 })
       await etherToken.approve(policy.address, 10000)
-      await policy.payTranchPremium(0, 1000)
-      await policy.payTranchPremium(1, 1000)
+      await policy.payTranchePremium(0, 1000)
+      await policy.payTranchePremium(1, 1000)
 
       await evmClock.setAbsoluteTime(initiationDate)
       await policy.checkAndUpdateState()
@@ -371,16 +373,16 @@ describe('Integration: SPV', () => {
         state_: POLICY_STATE_INITIATED
       })
 
-      await policy.getTranchInfo(0).should.eventually.matchObj({
+      await policy.getTrancheInfo(0).should.eventually.matchObj({
         sharesSold_: 0,
       })
-      await policy.getTranchInfo(1).should.eventually.matchObj({
+      await policy.getTrancheInfo(1).should.eventually.matchObj({
         sharesSold_: 0,
       })
 
-      tranchToken = await getTranchToken(0)
+      trancheToken = await getTrancheToken(0)
 
-      ;({ initialSaleOfferId_: marketOfferId } = await policy.getTranchInfo(0))
+      ;({ initialSaleOfferId_: marketOfferId } = await policy.getTrancheInfo(0))
 
       // get some wrapped ETH for buyer account
       await etherToken.deposit({ from: accounts[2], value: 25 })
@@ -397,32 +399,32 @@ describe('Integration: SPV', () => {
         await etherToken.balanceOf(policy.address).should.eventually.eq(180) /* commissions from premium payments = 9% of 2000 */
         await etherToken.balanceOf(entity.address).should.eventually.eq(1820) /* premium payments - minus commissions */
         await etherToken.balanceOf(market.address).should.eventually.eq(0)
-        await tranchToken.balanceOf(accounts[2]).should.eventually.eq(0)
-        await tranchToken.balanceOf(entity.address).should.eventually.eq(0)
-        await tranchToken.balanceOf(market.address).should.eventually.eq(100)
+        await trancheToken.balanceOf(accounts[2]).should.eventually.eq(0)
+        await trancheToken.balanceOf(entity.address).should.eventually.eq(0)
+        await trancheToken.balanceOf(market.address).should.eventually.eq(100)
 
         // make the offer on the market
         await etherToken.approve(market.address, 10, { from: accounts[2] })
-        await market.executeLimitOffer(etherToken.address, 10, tranchToken.address, 5000, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+        await market.executeLimitOffer(etherToken.address, 10, trancheToken.address, 5000, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
 
         // check balances again
         await etherToken.balanceOf(accounts[2]).should.eventually.eq(15)
         await etherToken.balanceOf(policy.address).should.eventually.eq(180)
         await etherToken.balanceOf(entity.address).should.eventually.eq(1820)
         await etherToken.balanceOf(market.address).should.eventually.eq(10)
-        await tranchToken.balanceOf(accounts[2]).should.eventually.eq(0)
-        await tranchToken.balanceOf(entity.address).should.eventually.eq(0)
-        await tranchToken.balanceOf(market.address).should.eventually.eq(100)
+        await trancheToken.balanceOf(accounts[2]).should.eventually.eq(0)
+        await trancheToken.balanceOf(entity.address).should.eventually.eq(0)
+        await trancheToken.balanceOf(market.address).should.eventually.eq(100)
       })
 
-      it('and tranch status is unchanged', async () => {
-        await policy.getTranchInfo(0).should.eventually.matchObj({
-          state_: TRANCH_STATE_SELLING,
+      it('and tranche status is unchanged', async () => {
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
+          state_: TRANCHE_STATE_SELLING,
         })
       })
 
-      it('and tranch balance is unchanged', async () => {
-        const b = (await policy.getTranchInfo(0)).balance_
+      it('and tranche balance is unchanged', async () => {
+        const b = (await policy.getTrancheInfo(0)).balance_
         expect(b.toNumber()).to.eq(calcPremiumsMinusCommissions({
           premiums: [1000],
           claimsAdminCommissionBP,
@@ -433,54 +435,54 @@ describe('Integration: SPV', () => {
       })
 
       it('and the tally of shares sold is unchanged', async () => {
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           sharesSold_: 0,
         })
       })
 
       it('and market offer is still active', async () => {
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           initialSaleOfferId_: marketOfferId,
         })
         await market.isActive(marketOfferId).should.eventually.eq(true)
       })
     })
 
-    describe('another party can make offers that do match but dont buy the tranch completely', () => {
+    describe('another party can make offers that do match but dont buy the tranche completely', () => {
       beforeEach(async () => {
         // check initial balances
         await etherToken.balanceOf(accounts[2]).should.eventually.eq(25)
         await etherToken.balanceOf(policy.address).should.eventually.eq(180) /* commissions from premium payments: 10 + 10 */
         await etherToken.balanceOf(entity.address).should.eventually.eq(1820) /* premium payments - minus commissions */
         await etherToken.balanceOf(market.address).should.eventually.eq(0)
-        await tranchToken.balanceOf(accounts[2]).should.eventually.eq(0)
-        await tranchToken.balanceOf(entity.address).should.eventually.eq(0)
-        await tranchToken.balanceOf(market.address).should.eventually.eq(100)
+        await trancheToken.balanceOf(accounts[2]).should.eventually.eq(0)
+        await trancheToken.balanceOf(entity.address).should.eventually.eq(0)
+        await trancheToken.balanceOf(market.address).should.eventually.eq(100)
 
         // make some offers on the market
         await etherToken.approve(market.address, 10, { from: accounts[2] })
-        await market.executeLimitOffer(etherToken.address, 4, tranchToken.address, 2, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
-        await market.executeLimitOffer(etherToken.address, 6, tranchToken.address, 3, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+        await market.executeLimitOffer(etherToken.address, 4, trancheToken.address, 2, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+        await market.executeLimitOffer(etherToken.address, 6, trancheToken.address, 3, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
 
         // check balances again
         await etherToken.balanceOf(accounts[2]).should.eventually.eq(15)
         await etherToken.balanceOf(policy.address).should.eventually.eq(180)
         await etherToken.balanceOf(entity.address).should.eventually.eq(1820 + 10)
         await etherToken.balanceOf(market.address).should.eventually.eq(0)
-        await tranchToken.balanceOf(accounts[2]).should.eventually.eq(5)
-        await tranchToken.balanceOf(entity.address).should.eventually.eq(0)
-        await tranchToken.balanceOf(market.address).should.eventually.eq(95)
+        await trancheToken.balanceOf(accounts[2]).should.eventually.eq(5)
+        await trancheToken.balanceOf(entity.address).should.eventually.eq(0)
+        await trancheToken.balanceOf(market.address).should.eventually.eq(95)
       })
 
-      it('and tranch status is unchanged', async () => {
-        // tranch status unchanged
-        await policy.getTranchInfo(0).should.eventually.matchObj({
-          state_: TRANCH_STATE_SELLING,
+      it('and tranche status is unchanged', async () => {
+        // tranche status unchanged
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
+          state_: TRANCHE_STATE_SELLING,
         })
       })
 
-      it('and tranch balance has been updated', async () => {
-        const b = (await policy.getTranchInfo(0)).balance_
+      it('and tranche balance has been updated', async () => {
+        const b = (await policy.getTrancheInfo(0)).balance_
         expect(b.toNumber()).to.eq(10 + calcPremiumsMinusCommissions({
           premiums: [1000],
           claimsAdminCommissionBP,
@@ -492,58 +494,58 @@ describe('Integration: SPV', () => {
 
       it('and tally of shares sold has been updated', async () => {
         // check shares sold
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           sharesSold_: 5,
         })
       })
 
       it('and market offer is still active', async () => {
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           initialSaleOfferId_: marketOfferId,
         })
         await market.isActive(marketOfferId).should.eventually.eq(true)
       })
     })
 
-    it('new token owners cannot trade their tokens whilst tranch is still selling', async () => {
-      // get tranch tokens
+    it('new token owners cannot trade their tokens whilst tranche is still selling', async () => {
+      // get tranche tokens
       await etherToken.approve(market.address, 10, { from: accounts[2] })
-      // buy the tranch token
-      await market.executeLimitOffer(etherToken.address, 10, tranchToken.address, 5, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+      // buy the tranche token
+      await market.executeLimitOffer(etherToken.address, 10, trancheToken.address, 5, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
       // check balance
-      await tranchToken.balanceOf(accounts[2]).should.eventually.eq(5)
-      // try trading the tranch token
-      // await market.executeLimitOffer(tranchToken.address, 1, etherToken.address, 1, FEE_SCHEDULE_STANDARD, { from: accounts[2] }).should.be.rejectedWith('can only trade when policy is active')
+      await trancheToken.balanceOf(accounts[2]).should.eventually.eq(5)
+      // try trading the tranche token
+      // await market.executeLimitOffer(trancheToken.address, 1, etherToken.address, 1, FEE_SCHEDULE_STANDARD, { from: accounts[2] }).should.be.rejectedWith('can only trade when policy is active')
     })
 
-    describe('if a tranch fully sells out', () => {
+    describe('if a tranche fully sells out', () => {
       let txResult
-      let tranchToken
+      let trancheToken
 
       beforeEach(async () => {
         // make the offer on the market
-        tranchToken = await getTranchToken(0)
+        trancheToken = await getTrancheToken(0)
 
-        // buy the whole tranch
+        // buy the whole tranche
         await etherToken.deposit({ from: accounts[2], value: 200 })
         await etherToken.approve(market.address, 200, { from: accounts[2] })
-        txResult = await market.executeLimitOffer(etherToken.address, 200, tranchToken.address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+        txResult = await market.executeLimitOffer(etherToken.address, 200, trancheToken.address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
       })
 
-      it('emits tranch state updated event', async () => {
-        const ev = extractEventArgs(txResult, events.TranchStateUpdated)
-        expect(ev.tranchIndex).to.eq('0')
-        expect(ev.state).to.eq(TRANCH_STATE_ACTIVE.toString())
+      it('emits tranche state updated event', async () => {
+        const ev = extractEventArgs(txResult, events.TrancheStateUpdated)
+        expect(ev.trancheIndex).to.eq('0')
+        expect(ev.state).to.eq(TRANCHE_STATE_ACTIVE.toString())
       })
 
       it('then its status is set to active', async () => {
-        await policy.getTranchInfo(0).should.eventually.matchObj({
-          state_: TRANCH_STATE_ACTIVE,
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
+          state_: TRANCHE_STATE_ACTIVE,
         })
       })
 
-      it('then tranch balance has been updated', async () => {
-        const b = (await policy.getTranchInfo(0)).balance_
+      it('then tranche balance has been updated', async () => {
+        const b = (await policy.getTrancheInfo(0)).balance_
         expect(b.toNumber()).to.eq(200 + calcPremiumsMinusCommissions({
           premiums: [1000],
           claimsAdminCommissionBP,
@@ -554,19 +556,19 @@ describe('Integration: SPV', () => {
       })
 
       it('and the tally of shares sold gets updated', async () => {
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           sharesSold_: 100,
         })
       })
 
       it('and the market offer is closed', async () => {
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           initialSaleOfferId_: marketOfferId,
         })
         await market.isActive(marketOfferId).should.eventually.eq(false)
       })
 
-      describe('tranch tokens support ERC-20 operations', () => {
+      describe('tranche tokens support ERC-20 operations', () => {
         let tokenHolder
         
         beforeEach(async () => {
@@ -574,15 +576,15 @@ describe('Integration: SPV', () => {
         })
 
         it('but sending one\'s own tokens is not possible', async () => {
-          await tranchToken.transfer(accounts[3], 1, { from: tokenHolder }).should.be.rejectedWith('only nayms market is allowed to transfer')
+          await trancheToken.transfer(accounts[3], 1, { from: tokenHolder }).should.be.rejectedWith('only nayms market is allowed to transfer')
         })
 
         it('but approving an address to send on one\'s behalf is not possible', async () => {
-          await tranchToken.approve(accounts[3], 1, { from: tokenHolder }).should.be.rejectedWith('only nayms market is allowed to transfer')
+          await trancheToken.approve(accounts[3], 1, { from: tokenHolder }).should.be.rejectedWith('only nayms market is allowed to transfer')
         })
 
         it('approving an address to send on one\'s behalf is possible if it is the market', async () => {
-          await tranchToken.approve(market.address, 1, { from: tokenHolder }).should.be.fulfilled
+          await trancheToken.approve(market.address, 1, { from: tokenHolder }).should.be.fulfilled
         })
 
         describe('such as market sending tokens on one\'s behalf', () => {
@@ -591,14 +593,14 @@ describe('Integration: SPV', () => {
           })
 
           it('but not when owner does not have enough', async () => {
-            await tranchToken.transferFrom(tokenHolder, accounts[5], 100 + 1, { from: accounts[3] }).should.be.rejectedWith('not enough balance')
+            await trancheToken.transferFrom(tokenHolder, accounts[5], 100 + 1, { from: accounts[3] }).should.be.rejectedWith('not enough balance')
           })
 
           it('when the owner has enough', async () => {
-            const result = await tranchToken.transferFrom(tokenHolder, accounts[5], 100, { from: accounts[3] })
+            const result = await trancheToken.transferFrom(tokenHolder, accounts[5], 100, { from: accounts[3] })
 
-            await tranchToken.balanceOf(tokenHolder).should.eventually.eq(0)
-            await tranchToken.balanceOf(accounts[5]).should.eventually.eq(100)
+            await trancheToken.balanceOf(tokenHolder).should.eventually.eq(0)
+            await trancheToken.balanceOf(accounts[5]).should.eventually.eq(100)
 
             expect(extractEventArgs(result, events.Transfer)).to.include({
               from: tokenHolder,
@@ -619,8 +621,8 @@ describe('Integration: SPV', () => {
     it('but not if start date has not passed', async () => {
       await etherToken.deposit({ value: 100000 })
       await etherToken.approve(policy.address, 1000000)
-      await policy.payTranchPremium(0, 1000)
-      await policy.payTranchPremium(1, 1000)
+      await policy.payTranchePremium(0, 1000)
+      await policy.payTranchePremium(1, 1000)
 
       await evmClock.setAbsoluteTime(initiationDate)
       await policy.checkAndUpdateState()
@@ -638,16 +640,16 @@ describe('Integration: SPV', () => {
         await etherToken.deposit({ value: 1000000 })
         await etherToken.approve(policy.address, 1000000)
 
-        await policy.payTranchPremium(0, 2000)
-        await policy.payTranchPremium(1, 2000)
+        await policy.payTranchePremium(0, 2000)
+        await policy.payTranchePremium(1, 2000)
 
         await evmClock.setAbsoluteTime(initiationDate)
 
         // kick-off the sale
         await policy.checkAndUpdateState()
 
-        ;({ initialSaleOfferId_: offerId0 } = await policy.getTranchInfo(0))
-        ;({ initialSaleOfferId_: offerId1 } = await policy.getTranchInfo(1))
+        ;({ initialSaleOfferId_: offerId0 } = await policy.getTrancheInfo(0))
+        ;({ initialSaleOfferId_: offerId1 } = await policy.getTrancheInfo(1))
         expect(offerId0).to.not.eq(0)
         expect(offerId1).to.not.eq(0)
       })
@@ -657,10 +659,10 @@ describe('Integration: SPV', () => {
         await evmClock.setAbsoluteTime(startDate)
         await policy.checkAndUpdateState()
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           initialSaleOfferId_: offerId0,
         })
-        await policy.getTranchInfo(1).should.eventually.matchObj({
+        await policy.getTrancheInfo(1).should.eventually.matchObj({
           initialSaleOfferId_: offerId1,
         })
 
@@ -672,16 +674,16 @@ describe('Integration: SPV', () => {
         await evmClock.setAbsoluteTime(startDate)
         const ret = await policy.checkAndUpdateState()
 
-        const evs = parseEvents(ret, events.TranchStateUpdated)
+        const evs = parseEvents(ret, events.TrancheStateUpdated)
         expect(evs.length).to.eq(2)
 
         const [ ev1, ev2 ] = evs
 
-        expect(ev1.args.tranchIndex).to.eq('0')
-        expect(ev1.args.state).to.eq(TRANCH_STATE_CANCELLED.toString())
+        expect(ev1.args.trancheIndex).to.eq('0')
+        expect(ev1.args.state).to.eq(TRANCHE_STATE_CANCELLED.toString())
 
-        expect(ev2.args.tranchIndex).to.eq('1')
-        expect(ev2.args.state).to.eq(TRANCH_STATE_CANCELLED.toString())
+        expect(ev2.args.trancheIndex).to.eq('1')
+        expect(ev2.args.state).to.eq(TRANCHE_STATE_CANCELLED.toString())
       })
 
       describe('even if none of the tranches are active the policy still gets made active', () => {
@@ -691,11 +693,11 @@ describe('Integration: SPV', () => {
 
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_ACTIVE })
 
-          await policy.getTranchInfo(0).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
         })
 
@@ -710,12 +712,12 @@ describe('Integration: SPV', () => {
 
       describe('one of the tranches can be active but its premiums might not be up-to-date, in which case it gets cancelled', () => {
         beforeEach(async () => {
-          const tranchToken = await getTranchToken(0)
+          const trancheToken = await getTrancheToken(0)
 
-          // buy the whole tranch to make it active
+          // buy the whole tranche to make it active
           await etherToken.deposit({ from: accounts[2], value: 1000000 })
           await etherToken.approve(market.address, 200, { from: accounts[2] })
-          await market.executeLimitOffer(etherToken.address, 200, tranchToken.address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+          await market.executeLimitOffer(etherToken.address, 200, trancheToken.address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
         })
 
         it('and updates internal state', async () => {
@@ -725,11 +727,11 @@ describe('Integration: SPV', () => {
 
           // now check
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_ACTIVE })
-          await policy.getTranchInfo(0).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
         })
 
@@ -738,28 +740,28 @@ describe('Integration: SPV', () => {
           await evmClock.setAbsoluteTime(startDate)
           const result = await policy.checkAndUpdateState()
 
-          const evs = parseEvents(result, events.TranchStateUpdated)
+          const evs = parseEvents(result, events.TrancheStateUpdated)
           expect(evs.length).to.eq(2)
 
           const evsStates = evs.map(e => e.args.state)
-          expect(evsStates[0]).to.eq(TRANCH_STATE_CANCELLED.toString())
-          expect(evsStates[1]).to.eq(TRANCH_STATE_CANCELLED.toString())
+          expect(evsStates[0]).to.eq(TRANCHE_STATE_CANCELLED.toString())
+          expect(evsStates[1]).to.eq(TRANCHE_STATE_CANCELLED.toString())
         })
       })
 
       describe('atleast one of the tranches can be active and its premiums can be up-to-date, in which case it stays active', () => {
         beforeEach(async () => {
           // make the offer on the market
-          const tranchToken = await getTranchToken(0)
+          const trancheToken = await getTrancheToken(0)
 
-          // buy the whole tranch to make it active
+          // buy the whole tranche to make it active
           await etherToken.deposit({ from: accounts[2], value: 1000000 })
           await etherToken.approve(market.address, 200, { from: accounts[2] })
-          const ret = await market.executeLimitOffer(etherToken.address, 200, tranchToken.address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+          const ret = await market.executeLimitOffer(etherToken.address, 200, trancheToken.address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
 
-          const ev = extractEventArgs(ret, events.TranchStateUpdated)
-          expect(ev.tranchIndex).to.eq('0')
-          expect(ev.state).to.eq(TRANCH_STATE_ACTIVE.toString())
+          const ev = extractEventArgs(ret, events.TrancheStateUpdated)
+          expect(ev.trancheIndex).to.eq('0')
+          expect(ev.state).to.eq(TRANCHE_STATE_ACTIVE.toString())
 
           // pay its premiums upto start date
           await etherToken.approve(policy.address, 1000000, { from: accounts[2] })
@@ -767,7 +769,7 @@ describe('Integration: SPV', () => {
           for (let i = 0; (startDate - initiationDate) / premiumIntervalSeconds >= i; i += 1) {
             toPay += (2000 + 1000 * i)
           }
-          await policy.payTranchPremium(0, toPay, { from: accounts[2] })
+          await policy.payTranchePremium(0, toPay, { from: accounts[2] })
         })
 
         it('updates internal state', async () => {
@@ -777,11 +779,11 @@ describe('Integration: SPV', () => {
 
           // now check
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_ACTIVE })
-          await policy.getTranchInfo(0).should.eventually.matchObj({
-            state_: TRANCH_STATE_ACTIVE,
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
+            state_: TRANCHE_STATE_ACTIVE,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
         })
 
@@ -790,40 +792,40 @@ describe('Integration: SPV', () => {
           await evmClock.setAbsoluteTime(startDate)
           const result = await policy.checkAndUpdateState()
 
-          const evs = parseEvents(result, events.TranchStateUpdated)
+          const evs = parseEvents(result, events.TrancheStateUpdated)
           expect(evs.length).to.eq(1)
 
           const [ ev ] = evs
-          expect(ev.args.state).to.eq(TRANCH_STATE_CANCELLED.toString())
-          expect(ev.args.tranchIndex).to.eq('1')
+          expect(ev.args.state).to.eq(TRANCHE_STATE_CANCELLED.toString())
+          expect(ev.args.trancheIndex).to.eq('1')
         })
       })
 
       it('once policy becomes active, then token owners can start trading', async () => {
         // make the offer on the market
-        const tranchToken = await getTranchToken(0)
+        const trancheToken = await getTrancheToken(0)
 
-        // buy the whole tranch to make it active
+        // buy the whole tranche to make it active
         await etherToken.deposit({ from: accounts[2], value: 2000000 })
         await etherToken.approve(market.address, 200, { from: accounts[2] })
-        await market.executeLimitOffer(etherToken.address, 200, tranchToken.address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+        await market.executeLimitOffer(etherToken.address, 200, trancheToken.address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
         // pay all premiums upto start date
         await etherToken.approve(policy.address, 1000000, { from: accounts[2] })
         let toPay = 0
         for (let i = 0; (startDate - initiationDate) / premiumIntervalSeconds >= i; i += 1) {
           toPay += (2000 + 1000 * i)
         }
-        await policy.payTranchPremium(0, toPay, { from: accounts[2] })
+        await policy.payTranchePremium(0, toPay, { from: accounts[2] })
 
         // end sale
         await evmClock.setAbsoluteTime(startDate)
         await policy.checkAndUpdateState()
 
         // try trading
-        await market.executeLimitOffer(tranchToken.address, 1, etherToken.address, 1, FEE_SCHEDULE_STANDARD, { from: accounts[2] }).should.be.fulfilled
+        await market.executeLimitOffer(trancheToken.address, 1, etherToken.address, 1, FEE_SCHEDULE_STANDARD, { from: accounts[2] }).should.be.fulfilled
 
         // check balance
-        await tranchToken.balanceOf(accounts[2]).should.eventually.eq(99)
+        await trancheToken.balanceOf(accounts[2]).should.eventually.eq(99)
       })
     })
   })
@@ -837,8 +839,8 @@ describe('Integration: SPV', () => {
       // pay first premiums
       await etherToken.deposit({ value: 1000000 })
       await etherToken.approve(policy.address, 1000000)
-      await policy.payTranchPremium(0, 1000)
-      await policy.payTranchPremium(1, 1000)
+      await policy.payTranchePremium(0, 1000)
+      await policy.payTranchePremium(1, 1000)
 
       // pass the inititation date
       await evmClock.setAbsoluteTime(initiationDate)
@@ -850,11 +852,11 @@ describe('Integration: SPV', () => {
       await etherToken.deposit({ value: 2000000, from: accounts[2] })
       await etherToken.approve(market.address, 2000000, { from: accounts[2] })
 
-      const tranch0Address = ((await getTranchToken(0))).address
-      await market.executeLimitOffer(etherToken.address, 200, tranch0Address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+      const tranche0Address = ((await getTrancheToken(0))).address
+      await market.executeLimitOffer(etherToken.address, 200, tranche0Address, 100, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
 
-      const tranch1Address = ((await getTranchToken(1))).address
-      await market.executeLimitOffer(etherToken.address, 100, tranch1Address, 50, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
+      const tranche1Address = ((await getTrancheToken(1))).address
+      await market.executeLimitOffer(etherToken.address, 100, tranche1Address, 50, FEE_SCHEDULE_STANDARD, { from: accounts[2] })
 
       // pay premiums upto start date
       let toPay = 0
@@ -862,8 +864,8 @@ describe('Integration: SPV', () => {
         nextPremium = (2000 + 1000 * i)
         toPay += nextPremium
       }
-      await policy.payTranchPremium(0, toPay)
-      await policy.payTranchPremium(1, toPay)
+      await policy.payTranchePremium(0, toPay)
+      await policy.payTranchePremium(1, toPay)
       nextPremium += 1000
 
       // pass the start date
@@ -874,50 +876,50 @@ describe('Integration: SPV', () => {
 
       // sanity check
       await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_ACTIVE })
-      await policy.getTranchInfo(0).should.eventually.matchObj({
-        state_: TRANCH_STATE_ACTIVE,
+      await policy.getTrancheInfo(0).should.eventually.matchObj({
+        state_: TRANCHE_STATE_ACTIVE,
       })
-      await policy.getTranchInfo(1).should.eventually.matchObj({
-        state_: TRANCH_STATE_ACTIVE,
+      await policy.getTrancheInfo(1).should.eventually.matchObj({
+        state_: TRANCHE_STATE_ACTIVE,
       })
     })
 
     it('and it remains active if all premium payments are up to date', async () => {
-      await policy.payTranchPremium(0, nextPremium)
-      await policy.payTranchPremium(1, nextPremium)
+      await policy.payTranchePremium(0, nextPremium)
+      await policy.payTranchePremium(1, nextPremium)
 
       await evmClock.moveTime(premiumIntervalSeconds)
       await policy.checkAndUpdateState()
 
       await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_ACTIVE })
-      await policy.getTranchInfo(0).should.eventually.matchObj({
-        state_: TRANCH_STATE_ACTIVE,
+      await policy.getTrancheInfo(0).should.eventually.matchObj({
+        state_: TRANCHE_STATE_ACTIVE,
       })
-      await policy.getTranchInfo(1).should.eventually.matchObj({
-        state_: TRANCH_STATE_ACTIVE,
+      await policy.getTrancheInfo(1).should.eventually.matchObj({
+        state_: TRANCHE_STATE_ACTIVE,
       })
     })
 
-    it('and it still stays active if any tranch premium payments have been missed, though that tranch gets cancelled', async () => {
-      await policy.payTranchPremium(0, nextPremium)
-      // await policy.payTranchPremium(1) - deliberately miss this payment
+    it('and it still stays active if any tranche premium payments have been missed, though that tranche gets cancelled', async () => {
+      await policy.payTranchePremium(0, nextPremium)
+      // await policy.payTranchePremium(1) - deliberately miss this payment
 
       await evmClock.moveTime(premiumIntervalSeconds)
       await policy.checkAndUpdateState()
 
       await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_ACTIVE })
-      await policy.getTranchInfo(0).should.eventually.matchObj({
-        state_: TRANCH_STATE_ACTIVE,
+      await policy.getTrancheInfo(0).should.eventually.matchObj({
+        state_: TRANCHE_STATE_ACTIVE,
       })
-      await policy.getTranchInfo(1).should.eventually.matchObj({
-        state_: TRANCH_STATE_CANCELLED,
+      await policy.getTrancheInfo(1).should.eventually.matchObj({
+        state_: TRANCHE_STATE_CANCELLED,
       })
     })
 
     describe('claims can be made', () => {
       beforeEach(async () => {
-        await policy.payTranchPremium(0, nextPremium)
-        await policy.payTranchPremium(1, nextPremium)
+        await policy.payTranchePremium(0, nextPremium)
+        await policy.payTranchePremium(1, nextPremium)
 
         await evmClock.moveTime(premiumIntervalSeconds)
         await policy.checkAndUpdateState()
@@ -942,35 +944,35 @@ describe('Integration: SPV', () => {
     describe('once maturation date has passed', () => {
       describe('if NOT all premium payments are up-to-date', () => {
         beforeEach(async () => {
-          await policy.payTranchPremium(0, nextPremium)
-          await policy.payTranchPremium(1, nextPremium)
+          await policy.payTranchePremium(0, nextPremium)
+          await policy.payTranchePremium(1, nextPremium)
         })
 
-        it('marks some tranches as cancelled and tries to buys back all tranch tokens', async () => {
+        it('marks some tranches as cancelled and tries to buys back all tranche tokens', async () => {
           await evmClock.setAbsoluteTime(maturationDate)
           const ret = await policy.checkAndUpdateState()
 
           const ev = extractEventArgs(ret, events.PolicyStateUpdated)
           expect(ev.state).to.eq(POLICY_STATE_BUYBACK.toString())
 
-          const evs = parseEvents(ret, events.TranchStateUpdated)
+          const evs = parseEvents(ret, events.TrancheStateUpdated)
           expect(evs.length).to.eq(2)
-          expect(evs[0].args.tranchIndex).to.eq('0')
-          expect(evs[0].args.state).to.eq(TRANCH_STATE_CANCELLED.toString())
-          expect(evs[1].args.tranchIndex).to.eq('1')
-          expect(evs[1].args.state).to.eq(TRANCH_STATE_CANCELLED.toString())
+          expect(evs[0].args.trancheIndex).to.eq('0')
+          expect(evs[0].args.state).to.eq(TRANCHE_STATE_CANCELLED.toString())
+          expect(evs[1].args.trancheIndex).to.eq('1')
+          expect(evs[1].args.state).to.eq(TRANCHE_STATE_CANCELLED.toString())
 
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
-          await policy.getTranchInfo(0).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
-          await policy.getTranchInfo(0).should.eventually.not.matchObj({
+          await policy.getTrancheInfo(0).should.eventually.not.matchObj({
             finalBuybackofferId_: 0,
           })
-          await policy.getTranchInfo(1).should.eventually.not.matchObj({
+          await policy.getTrancheInfo(1).should.eventually.not.matchObj({
             finalBuybackofferId_: 0,
           })
         })
@@ -987,15 +989,15 @@ describe('Integration: SPV', () => {
 
             const ev = extractEventArgs(ret, events.PolicyStateUpdated)
             expect(ev.state).to.eq(POLICY_STATE_MATURED.toString())
-            const preEvs = parseEvents(ret, events.TranchStateUpdated).filter(e => e.args.state === TRANCH_STATE_CANCELLED.toString())
+            const preEvs = parseEvents(ret, events.TrancheStateUpdated).filter(e => e.args.state === TRANCHE_STATE_CANCELLED.toString())
             expect(preEvs.length).to.eq(2)
 
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_MATURED })
 
-            await policy.getTranchInfo(0).should.eventually.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.matchObj({
               finalBuybackofferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.matchObj({
               finalBuybackofferId_: 0,
             })
 
@@ -1006,13 +1008,13 @@ describe('Integration: SPV', () => {
             const ev2 = extractEventArgs(ret2, events.PolicyStateUpdated)
             expect(ev2.state).to.eq(POLICY_STATE_BUYBACK.toString())
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
-            const postEvs = parseEvents(ret2, events.TranchStateUpdated)
+            const postEvs = parseEvents(ret2, events.TrancheStateUpdated)
             expect(postEvs.length).to.eq(0) // tranches are already cancelled, and so stay that way
 
-            await policy.getTranchInfo(0).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.not.matchObj({
               finalBuybackofferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.not.matchObj({
               finalBuybackofferId_: 0,
             })
           })
@@ -1029,10 +1031,10 @@ describe('Integration: SPV', () => {
 
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_MATURED })
 
-            await policy.getTranchInfo(0).should.eventually.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.matchObj({
               finalBuybackofferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.matchObj({
               finalBuybackofferId_: 0,
             })
 
@@ -1043,10 +1045,10 @@ describe('Integration: SPV', () => {
             expect(ev2.state).to.eq(POLICY_STATE_BUYBACK.toString())
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
 
-            await policy.getTranchInfo(0).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.not.matchObj({
               finalBuybackofferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.not.matchObj({
               finalBuybackofferId_: 0,
             })
           })
@@ -1056,24 +1058,24 @@ describe('Integration: SPV', () => {
           await evmClock.setAbsoluteTime(maturationDate)
           await policy.checkAndUpdateState()
 
-          const { finalBuybackofferId_: offer1 } = await policy.getTranchInfo(0)
+          const { finalBuybackofferId_: offer1 } = await policy.getTrancheInfo(0)
           expect(offer1).to.not.eq(0)
-          const { finalBuybackofferId_: offer2 } = await policy.getTranchInfo(1)
+          const { finalBuybackofferId_: offer2 } = await policy.getTrancheInfo(1)
           expect(offer2).to.not.eq(0)
 
           await policy.checkAndUpdateState()
 
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
-          await policy.getTranchInfo(0).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
-            state_: TRANCH_STATE_CANCELLED,
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
+            state_: TRANCHE_STATE_CANCELLED,
           })
-          await policy.getTranchInfo(0).should.eventually.matchObj({
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
             finalBuybackofferId_: offer1,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
             finalBuybackofferId_: offer2,
           })
         })
@@ -1087,7 +1089,7 @@ describe('Integration: SPV', () => {
 
       describe('if all premium payments are up-to-date', () => {
         beforeEach(async () => {
-          const t0 = await policy.getTranchPremiumsInfo(0)
+          const t0 = await policy.getTranchePremiumsInfo(0)
           let nextPremiumAmount0 = t0.nextPremiumAmount_.toNumber()
           const numPremiums0 = t0.numPremiums_.toNumber()
           const numPremiumsPaid0 = t0.numPremiumsPaid_.toNumber()
@@ -1096,9 +1098,9 @@ describe('Integration: SPV', () => {
             toPay0 += nextPremiumAmount0
             nextPremiumAmount0 += 1000
           }
-          await policy.payTranchPremium(0, toPay0)
+          await policy.payTranchePremium(0, toPay0)
 
-          const t1 = await policy.getTranchPremiumsInfo(1)
+          const t1 = await policy.getTranchePremiumsInfo(1)
           let nextPremiumAmount1 = t1.nextPremiumAmount_.toNumber()
           const numPremiums1 = t1.numPremiums_.toNumber()
           const numPremiumsPaid1 = t1.numPremiumsPaid_.toNumber()
@@ -1107,30 +1109,30 @@ describe('Integration: SPV', () => {
             toPay1 += nextPremiumAmount1
             nextPremiumAmount1 += 1000
           }
-          await policy.payTranchPremium(1, toPay1)
+          await policy.payTranchePremium(1, toPay1)
         })
 
-        it('tries to buys back all tranch tokens, and all tranches are matured', async () => {
+        it('tries to buys back all tranche tokens, and all tranches are matured', async () => {
           await evmClock.setAbsoluteTime(maturationDate)
           const ret = await policy.checkAndUpdateState()
 
           const ev = extractEventArgs(ret, events.PolicyStateUpdated)
           expect(ev.state).to.eq(POLICY_STATE_BUYBACK.toString())
 
-          const tEvs = parseEvents(ret, events.TranchStateUpdated).filter(e => e.args.state === TRANCH_STATE_MATURED.toString())
+          const tEvs = parseEvents(ret, events.TrancheStateUpdated).filter(e => e.args.state === TRANCHE_STATE_MATURED.toString())
           expect(tEvs.length).to.eq(2)
 
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
-          await policy.getTranchInfo(0).should.eventually.matchObj({
-            state_: TRANCH_STATE_MATURED,
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
+            state_: TRANCHE_STATE_MATURED,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
-            state_: TRANCH_STATE_MATURED,
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
+            state_: TRANCHE_STATE_MATURED,
           })
-          await policy.getTranchInfo(0).should.eventually.not.matchObj({
+          await policy.getTrancheInfo(0).should.eventually.not.matchObj({
             finalBuybackofferId_: 0,
           })
-          await policy.getTranchInfo(1).should.eventually.not.matchObj({
+          await policy.getTrancheInfo(1).should.eventually.not.matchObj({
             finalBuybackofferId_: 0,
           })
         })
@@ -1148,14 +1150,14 @@ describe('Integration: SPV', () => {
             const ev = extractEventArgs(ret, events.PolicyStateUpdated)
             expect(ev.state).to.eq(POLICY_STATE_MATURED.toString())
 
-            const preEvs = parseEvents(ret, events.TranchStateUpdated)
+            const preEvs = parseEvents(ret, events.TrancheStateUpdated)
             expect(preEvs.length).to.eq(0)
 
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_MATURED })
-            await policy.getTranchInfo(0).should.eventually.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.matchObj({
               finalBuybackofferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.matchObj({
               finalBuybackofferId_: 0,
             })
 
@@ -1167,16 +1169,16 @@ describe('Integration: SPV', () => {
             expect(ev2.state).to.eq(POLICY_STATE_BUYBACK.toString())
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
 
-            const postEvs = parseEvents(ret2, events.TranchStateUpdated)
+            const postEvs = parseEvents(ret2, events.TrancheStateUpdated)
             expect(postEvs.length).to.eq(2)
             const postEvStates = postEvs.map(e => e.args.state)
-            expect(postEvStates[0]).to.eq(TRANCH_STATE_MATURED.toString())
-            expect(postEvStates[1]).to.eq(TRANCH_STATE_MATURED.toString())
+            expect(postEvStates[0]).to.eq(TRANCHE_STATE_MATURED.toString())
+            expect(postEvStates[1]).to.eq(TRANCHE_STATE_MATURED.toString())
 
-            await policy.getTranchInfo(0).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.not.matchObj({
               finalBuybackofferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.not.matchObj({
               finalBuybackofferId_: 0,
             })
           })
@@ -1193,10 +1195,10 @@ describe('Integration: SPV', () => {
 
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_MATURED })
 
-            await policy.getTranchInfo(0).should.eventually.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.matchObj({
               finalBuybackofferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.matchObj({
               finalBuybackofferId_: 0,
             })
 
@@ -1207,10 +1209,10 @@ describe('Integration: SPV', () => {
             expect(ev2.state).to.eq(POLICY_STATE_BUYBACK.toString())
             await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
 
-            await policy.getTranchInfo(0).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(0).should.eventually.not.matchObj({
               finalBuybackofferId_: 0,
             })
-            await policy.getTranchInfo(1).should.eventually.not.matchObj({
+            await policy.getTrancheInfo(1).should.eventually.not.matchObj({
               finalBuybackofferId_: 0,
             })
           })
@@ -1220,24 +1222,24 @@ describe('Integration: SPV', () => {
           await evmClock.setAbsoluteTime(maturationDate)
           await policy.checkAndUpdateState()
 
-          const { finalBuybackofferId_: offer1 } = await policy.getTranchInfo(0)
+          const { finalBuybackofferId_: offer1 } = await policy.getTrancheInfo(0)
           expect(offer1).to.not.eq(0)
-          const { finalBuybackofferId_: offer2 } = await policy.getTranchInfo(1)
+          const { finalBuybackofferId_: offer2 } = await policy.getTrancheInfo(1)
           expect(offer2).to.not.eq(0)
 
           await policy.checkAndUpdateState()
 
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
-          await policy.getTranchInfo(0).should.eventually.matchObj({
-            state_: TRANCH_STATE_MATURED,
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
+            state_: TRANCHE_STATE_MATURED,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
-            state_: TRANCH_STATE_MATURED,
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
+            state_: TRANCHE_STATE_MATURED,
           })
-          await policy.getTranchInfo(0).should.eventually.matchObj({
+          await policy.getTrancheInfo(0).should.eventually.matchObj({
             finalBuybackofferId_: offer1,
           })
-          await policy.getTranchInfo(1).should.eventually.matchObj({
+          await policy.getTrancheInfo(1).should.eventually.matchObj({
             finalBuybackofferId_: offer2,
           })
         })
@@ -1251,7 +1253,7 @@ describe('Integration: SPV', () => {
 
       describe('once it tries to buy back all tokens', async () => {
         beforeEach(async () => {
-          const t0 = await policy.getTranchPremiumsInfo(0)     
+          const t0 = await policy.getTranchePremiumsInfo(0)     
           const numPremiums0 = t0.numPremiums_.toNumber()
           let numPremiumsPaid0 = t0.numPremiumsPaid_.toNumber()
           let nextPremiumAmount0 = t0.nextPremiumAmount_.toNumber()
@@ -1260,9 +1262,9 @@ describe('Integration: SPV', () => {
             toPay0 += nextPremiumAmount0
             nextPremiumAmount0 += 1000
           }
-          await policy.payTranchPremium(0, toPay0)
+          await policy.payTranchePremium(0, toPay0)
 
-          const t1 = await policy.getTranchPremiumsInfo(1)
+          const t1 = await policy.getTranchePremiumsInfo(1)
           let nextPremiumAmount1 = t1.nextPremiumAmount_.toNumber()
           const numPremiums1 = t1.numPremiums_.toNumber()
           const numPremiumsPaid1 = t1.numPremiumsPaid_.toNumber()
@@ -1271,7 +1273,7 @@ describe('Integration: SPV', () => {
             toPay1 += nextPremiumAmount1
             nextPremiumAmount1 += 1000  
           }
-          await policy.payTranchPremium(1, toPay1)
+          await policy.payTranchePremium(1, toPay1)
 
           await evmClock.setAbsoluteTime(maturationDate)
           await policy.checkAndUpdateState()
@@ -1280,25 +1282,25 @@ describe('Integration: SPV', () => {
         })
 
         it('the market offer uses the "platform action" fee schedule', async () => {
-          const { finalBuybackofferId_: buybackOfferId } = await policy.getTranchInfo(0)
+          const { finalBuybackofferId_: buybackOfferId } = await policy.getTrancheInfo(0)
 
           await market.getOffer(buybackOfferId).should.eventually.matchObj({
             feeSchedule_: FEE_SCHEDULE_PLATFORM_ACTION,
           })
         })
 
-        it('other people can trade their previously purchased tranch tokens in for (hopefully) profit ', async () => {
-          const tranchTkn = await getTranchToken(0)
+        it('other people can trade their previously purchased tranche tokens in for (hopefully) profit ', async () => {
+          const trancheTkn = await getTrancheToken(0)
 
-          const treasuryPreBalance = (await tranchTkn.balanceOf(entity.address)).toNumber()
+          const treasuryPreBalance = (await trancheTkn.balanceOf(entity.address)).toNumber()
 
           const preBalance = (await etherToken.balanceOf(accounts[2])).toNumber()
 
-          const { finalBuybackofferId_: buybackOfferId } = await policy.getTranchInfo(0)
+          const { finalBuybackofferId_: buybackOfferId } = await policy.getTrancheInfo(0)
 
-          const tranch0Address = (await getTranchToken(0)).address
+          const tranche0Address = (await getTrancheToken(0)).address
 
-          await market.executeMarketOffer(tranch0Address, 100, etherToken.address, { from: accounts[2] });
+          await market.executeMarketOffer(tranche0Address, 100, etherToken.address, { from: accounts[2] });
 
           // check that order has been fulfilled
           await market.isActive(buybackOfferId).should.eventually.eq(false)
@@ -1315,60 +1317,60 @@ describe('Integration: SPV', () => {
 
           expect(postBalance - preBalance).to.eq(200 + expectedPremiumBalance) /* 200 = initial sold amount */
 
-          const treasuryPostBalance = (await tranchTkn.balanceOf(entity.address)).toNumber()
+          const treasuryPostBalance = (await trancheTkn.balanceOf(entity.address)).toNumber()
 
           expect(treasuryPostBalance - treasuryPreBalance).to.eq(100)
         })
 
-        it('keeps track of when a tranch has been totally bought back', async () => {
-          const tranchTkn = await getTranchToken(0)
+        it('keeps track of when a tranche has been totally bought back', async () => {
+          const trancheTkn = await getTrancheToken(0)
 
-          await tranchTkn.balanceOf(entity.address).should.eventually.eq(0)
+          await trancheTkn.balanceOf(entity.address).should.eventually.eq(0)
 
-          const numShares = (await policy.getTranchInfo(0)).numShares_.toNumber()
+          const numShares = (await policy.getTrancheInfo(0)).numShares_.toNumber()
           
-          expect((await policy.getTranchInfo(0)).buybackCompleted_).to.eq(false)
+          expect((await policy.getTrancheInfo(0)).buybackCompleted_).to.eq(false)
 
-          const { finalBuybackofferId_: buybackOfferId } = await policy.getTranchInfo(0)
+          const { finalBuybackofferId_: buybackOfferId } = await policy.getTrancheInfo(0)
 
           const offer = await market.getOffer(buybackOfferId)
 
-          await market.executeMarketOffer(tranchTkn.address, offer.buyAmount_, etherToken.address, { from: accounts[2] });
+          await market.executeMarketOffer(trancheTkn.address, offer.buyAmount_, etherToken.address, { from: accounts[2] });
 
-          await tranchTkn.balanceOf(entity.address).should.eventually.eq(numShares)
+          await trancheTkn.balanceOf(entity.address).should.eventually.eq(numShares)
  
-          expect((await policy.getTranchInfo(0)).buybackCompleted_).to.eq(true)
+          expect((await policy.getTrancheInfo(0)).buybackCompleted_).to.eq(true)
         })
 
         it('sets policy to closed once all tranches have been fully bought back', async () => {
-          // buyback tranch 0
-          expect((await policy.getTranchInfo(0)).buybackCompleted_).to.eq(false)
+          // buyback tranche 0
+          expect((await policy.getTrancheInfo(0)).buybackCompleted_).to.eq(false)
 
-          const tranchTkn0 = await getTranchToken(0)
+          const trancheTkn0 = await getTrancheToken(0)
 
-          const { finalBuybackofferId_: buybackOfferId0 } = await policy.getTranchInfo(0)
+          const { finalBuybackofferId_: buybackOfferId0 } = await policy.getTrancheInfo(0)
 
           const offer0 = await market.getOffer(buybackOfferId0)
 
-          await market.executeMarketOffer(tranchTkn0.address, offer0.buyAmount_, etherToken.address, { from: accounts[2] });
+          await market.executeMarketOffer(trancheTkn0.address, offer0.buyAmount_, etherToken.address, { from: accounts[2] });
 
-          expect((await policy.getTranchInfo(0)).buybackCompleted_).to.eq(true)
+          expect((await policy.getTrancheInfo(0)).buybackCompleted_).to.eq(true)
 
           // check: policy still in buyback state
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_BUYBACK })
 
-          // buyback tranch 1
-          expect((await policy.getTranchInfo(1)).buybackCompleted_).to.eq(false)
+          // buyback tranche 1
+          expect((await policy.getTrancheInfo(1)).buybackCompleted_).to.eq(false)
 
-          const tranchTkn1 = await getTranchToken(1)
+          const trancheTkn1 = await getTrancheToken(1)
 
-          const { finalBuybackofferId_: buybackOfferId1 } = await policy.getTranchInfo(1)
+          const { finalBuybackofferId_: buybackOfferId1 } = await policy.getTrancheInfo(1)
 
           const offer1 = await market.getOffer(buybackOfferId1)
 
-          await market.executeMarketOffer(tranchTkn1.address, offer1.buyAmount_, etherToken.address, { from: accounts[2] });
+          await market.executeMarketOffer(trancheTkn1.address, offer1.buyAmount_, etherToken.address, { from: accounts[2] });
 
-          expect((await policy.getTranchInfo(1)).buybackCompleted_).to.eq(true)
+          expect((await policy.getTrancheInfo(1)).buybackCompleted_).to.eq(true)
 
           // check: policy now closed
           await policy.getInfo().should.eventually.matchObj({ state_: POLICY_STATE_CLOSED })

--- a/test/policyApprovals.js
+++ b/test/policyApprovals.js
@@ -2,7 +2,7 @@ import {
   uuid,
   extractEventArgs,
   parseEvents,
-  createTranch,
+  createTranche,
   createPolicy,
   doPolicyApproval,
   generateApprovalSignatures,
@@ -126,8 +126,17 @@ describe('Policy: Approvals', () => {
     initiationDate = baseDate + 1000
     startDate = initiationDate + 1000
     maturationDate = startDate + 2000
-    premiumIntervalSeconds = 500
-    const trancheData = [[100, 2, 10, 20, 30, 40, 50, 60, 70]]
+    // premiumIntervalSeconds = 500
+    // const trancheData = [[100, 2, 10, 20, 30, 40, 50, 60, 70]]
+    const trancheData = 
+    [[100, 2, 
+      initiationDate + 0, 10 ,
+      initiationDate + 500 , 20,
+      initiationDate + 1000, 30,
+      initiationDate + 1500, 40,
+      initiationDate + 2000, 50,
+      initiationDate + 2500, 60,
+      initiationDate + 3000, 70 ]]
 
     policyId = keccak256(uuid())
 
@@ -136,7 +145,7 @@ describe('Policy: Approvals', () => {
       initiationDate,
       startDate,
       maturationDate,
-      premiumIntervalSeconds,
+      // premiumIntervalSeconds,
       unit: etherToken.address,
       claimsAdminCommissionBP,
       brokerCommissionBP,
@@ -158,10 +167,11 @@ describe('Policy: Approvals', () => {
     market = await ensureMarketIsDeployed({ artifacts, settings })
 
     // setup second tranche. First one was set in the createPolicy call
-    await createTranch(policy, {
+    await createTranche(policy, {
       numShares: 50,
       pricePerShareAmount: 2,
-      premiums: [10, 20, 30, 40, 50, 60, 70],
+      // premiums: [10, 20, 30, 40, 50, 60, 70],
+      premiumsDiff: [0, 10 ,500 , 20, 1000, 30, 1500, 40, 2000, 50, 2500, 60, 3000, 70 ]
     }, { from: policyOwnerAddress })
 
     const policyStates = await IPolicyStates.at(policyCoreAddress)

--- a/test/policyBasic.js
+++ b/test/policyBasic.js
@@ -42,7 +42,7 @@ const POLICY_ATTRS_1 = {
   initiationDateDiff: 1000,
   startDateDiff: 2000,
   maturationDateDiff: 3000,
-  premiumIntervalSeconds: undefined,
+  // premiumIntervalSeconds: undefined,
   brokerCommissionBP: 0,
   underwriterCommissionBP: 0,
   claimsAdminCommissionBP: 0,
@@ -50,7 +50,7 @@ const POLICY_ATTRS_1 = {
 }
 
 const POLICY_ATTRS_2 = Object.assign({}, POLICY_ATTRS_1, {
-  premiumIntervalSeconds: 5,
+  // premiumIntervalSeconds: 5,
   brokerCommissionBP: 2,
   claimsAdminCommissionBP: 1,
   naymsCommissionBP: 3,
@@ -59,8 +59,11 @@ const POLICY_ATTRS_2 = Object.assign({}, POLICY_ATTRS_1, {
 
 const POLICY_ATTRS_3 = Object.assign({}, POLICY_ATTRS_2, {
   policyId: policyId3,
-  trancheData: [[100, 2, 10, 20, 30, 40, 50, 60, 70], [50, 2, 10, 20, 30, 40, 50, 60, 70]]
-})
+  // trancheDiffData: [[100, 2, 10, 20, 30, 40, 50, 60, 70], [50, 2, 10, 20, 30, 40, 50, 60, 70]]
+  trancheDataDiff: [
+    [100, 2, 0 , 10 ,5, 20 ,10, 30 ,15, 40 ,20, 50 ,25, 60 ,30, 70], 
+    [50, 2, 0 , 10 ,5, 20 ,10, 30 ,15, 40 ,20, 50 ,25, 60 ,30, 70]]
+  })
 
 describe('Policy: Basic', () => {
   const evmSnapshot = new EvmSnapshot()
@@ -91,9 +94,9 @@ describe('Policy: Basic', () => {
 
   let POLICY_TYPE_SPV
 
-  let TRANCH_STATE_CANCELLED
-  let TRANCH_STATE_ACTIVE
-  let TRANCH_STATE_MATURED
+  let TRANCHE_STATE_CANCELLED
+  let TRANCHE_STATE_ACTIVE
+  let TRANCHE_STATE_MATURED
 
   const policies = new Map()
   let setupPolicy
@@ -138,9 +141,9 @@ describe('Policy: Basic', () => {
     POLICY_STATE_INITIATED = await policyStates.POLICY_STATE_INITIATED()
     POLICY_STATE_ACTIVE = await policyStates.POLICY_STATE_ACTIVE()
     POLICY_STATE_MATURED = await policyStates.POLICY_STATE_MATURED()
-    TRANCH_STATE_CANCELLED = await policyStates.TRANCH_STATE_CANCELLED()
-    TRANCH_STATE_ACTIVE = await policyStates.TRANCH_STATE_ACTIVE()
-    TRANCH_STATE_MATURED = await policyStates.TRANCH_STATE_MATURED()
+    TRANCHE_STATE_CANCELLED = await policyStates.TRANCHE_STATE_CANCELLED()
+    TRANCHE_STATE_ACTIVE = await policyStates.TRANCHE_STATE_ACTIVE()
+    TRANCHE_STATE_MATURED = await policyStates.TRANCHE_STATE_MATURED()
     const policyTypes = await IPolicyTypes.at(policyCoreAddress)
     POLICY_TYPE_SPV = await policyTypes.POLICY_TYPE_SPV()
 
@@ -206,7 +209,7 @@ describe('Policy: Basic', () => {
         startDate_: attrs.startDate,
         maturationDate_: attrs.maturationDate,
         unit_: attrs.unit,
-        premiumIntervalSeconds_: 5,
+        // premiumIntervalSeconds_: 5,
         numTranches_: 2,
         state_: POLICY_STATE_CREATED,
         type_: POLICY_TYPE_SPV,
@@ -255,7 +258,7 @@ describe('Policy: Basic', () => {
 
     it('and points to the new implementation', async () => {
       await policyDelegate.upgrade([dummyPolicyFacet.address]).should.be.fulfilled
-      await policy.calculateMaxNumOfPremiums().should.eventually.eq(666);
+      // await policy.calculateMaxNumOfPremiums().should.eventually.eq(666);
     })
 
     it('and can be frozen', async () => {

--- a/test/policyCommissions.js
+++ b/test/policyCommissions.js
@@ -4,7 +4,7 @@ import {
   extractEventArgs,
   hdWallet,
   ADDRESS_ZERO,
-  createTranch,
+  createTranche,
   createEntity,
   preSetupPolicy,
   doPolicyApproval,
@@ -33,7 +33,7 @@ const POLICY_ATTRS_1 = {
   initiationDateDiff: 1000,
   startDateDiff: 2000,
   maturationDateDiff: 3000,
-  premiumIntervalSeconds: 30,
+  // premiumIntervalSeconds: 30,
   claimsAdminCommissionBP: 10, /* 0.1% */
   brokerCommissionBP: 20, /* 0.2% */
   naymsCommissionBP: 30, /* 0.3% */
@@ -78,9 +78,9 @@ describe('Policy: Commissions', () => {
   let POLICY_STATE_MATURED
   let POLICY_STATE_APPROVED
 
-  let TRANCH_STATE_CANCELLED
-  let TRANCH_STATE_ACTIVE
-  let TRANCH_STATE_MATURED
+  let TRANCHE_STATE_CANCELLED
+  let TRANCHE_STATE_ACTIVE
+  let TRANCHE_STATE_MATURED
 
   let setupPolicy
   let approvePolicy
@@ -141,9 +141,9 @@ describe('Policy: Commissions', () => {
     POLICY_STATE_ACTIVE = await policyStates.POLICY_STATE_ACTIVE()
     POLICY_STATE_MATURED = await policyStates.POLICY_STATE_MATURED()
     POLICY_STATE_APPROVED = await policyStates.POLICY_STATE_APPROVED()
-    TRANCH_STATE_CANCELLED = await policyStates.TRANCH_STATE_CANCELLED()
-    TRANCH_STATE_ACTIVE = await policyStates.TRANCH_STATE_ACTIVE()
-    TRANCH_STATE_MATURED = await policyStates.TRANCH_STATE_MATURED()
+    TRANCHE_STATE_CANCELLED = await policyStates.TRANCHE_STATE_CANCELLED()
+    TRANCHE_STATE_ACTIVE = await policyStates.TRANCHE_STATE_ACTIVE()
+    TRANCHE_STATE_MATURED = await policyStates.TRANCHE_STATE_MATURED()
 
     const preSetupPolicyCtx = { policies, settings, events, etherToken, entity, entityManagerAddress }
     await Promise.all([
@@ -179,8 +179,9 @@ describe('Policy: Commissions', () => {
     beforeEach(async () => {
       await setupPolicy(POLICY_ATTRS_1)
 
-      await createTranch(policy, {
-        premiums: [2000, 3000, 4000]
+      await createTranche(policy, {
+        // premiums: [2000, 3000, 4000]
+        premiumsDiff: [0, 2000, 30, 3000, 60, 4000]
       }, { from: policyOwnerAddress })
     })
 
@@ -188,7 +189,7 @@ describe('Policy: Commissions', () => {
       await etherToken.deposit({ value: 10000 })
       await etherToken.approve(policy.address, 10000)
 
-      await policy.payTranchPremium(0, 2000)
+      await policy.payTranchePremium(0, 2000)
 
       await policy.getCommissionBalances().should.eventually.matchObj({
         claimsAdminCommissionBalance_: 2, /* 0.1% of 2000 */
@@ -197,11 +198,11 @@ describe('Policy: Commissions', () => {
         underwriterCommissionBalance_: 8, /* 0.4% of 2000 */
       })
 
-      await policy.getTranchInfo(0).should.eventually.matchObj({
+      await policy.getTrancheInfo(0).should.eventually.matchObj({
         balance_: 1980, /* 2000 - (2 + 4 + 6 + 8) */
       })
 
-      await policy.payTranchPremium(0, 3000)
+      await policy.payTranchePremium(0, 3000)
 
       await policy.getCommissionBalances().should.eventually.matchObj({
         claimsAdminCommissionBalance_: 5, /* 2 + 3 (=0.1% of 3000) */
@@ -209,11 +210,11 @@ describe('Policy: Commissions', () => {
         naymsCommissionBalance_: 15, /* 6 + 9 (=0.3% of 3000) */
         underwriterCommissionBalance_: 20, /* 8 + 12 (=0.4% of 3000) */
       })
-      await policy.getTranchInfo(0).should.eventually.matchObj({
+      await policy.getTrancheInfo(0).should.eventually.matchObj({
         balance_: 4950, /* 1980 + 3000 - (3 + 6 + 9 + 12) */
       })
 
-      await policy.payTranchPremium(0, 4000)
+      await policy.payTranchePremium(0, 4000)
 
       await policy.getCommissionBalances().should.eventually.matchObj({
         claimsAdminCommissionBalance_: 9, /* 5 + 4 (=0.1% of 4000) */
@@ -221,7 +222,7 @@ describe('Policy: Commissions', () => {
         naymsCommissionBalance_: 27, /* 15 + 12 (=0.3% of 4000) */
         underwriterCommissionBalance_: 36, /* 20 + 16 (=0.4% of 4000) */
       })
-      await policy.getTranchInfo(0).should.eventually.matchObj({
+      await policy.getTrancheInfo(0).should.eventually.matchObj({
         balance_: 8910, /* 4950 + 4000 - (4 + 8 + 12 + 16) */
       })
 
@@ -234,7 +235,7 @@ describe('Policy: Commissions', () => {
       await etherToken.deposit({ value: 10000 })
       await etherToken.approve(policy.address, 10000)
 
-      await policy.payTranchPremium(0, 4000)
+      await policy.payTranchePremium(0, 4000)
 
       await policy.getCommissionBalances().should.eventually.matchObj({
         claimsAdminCommissionBalance_: 4, /* 0.1% of 4000 */
@@ -243,7 +244,7 @@ describe('Policy: Commissions', () => {
         underwriterCommissionBalance_: 16, /* 0.4% of 4000 */
       })
 
-      await policy.getTranchInfo(0).should.eventually.matchObj({
+      await policy.getTrancheInfo(0).should.eventually.matchObj({
         balance_: 3960, /* 4000 - (4 + 8 + 12 + 16) */
       })
     })
@@ -278,7 +279,7 @@ describe('Policy: Commissions', () => {
         })
 
         it('and funds get transferred', async () => {
-          await policy.payTranchPremium(0, 5000)
+          await policy.payTranchePremium(0, 5000)
 
           const preBalance1 = (await etherToken.balanceOf(claimsAdmin)).toNumber()
           const preBalance2 = (await etherToken.balanceOf(broker)).toNumber()
@@ -312,7 +313,7 @@ describe('Policy: Commissions', () => {
           await policy.payCommissions()
           await policy.payCommissions()
 
-          await policy.payTranchPremium(0, 4000)
+          await policy.payTranchePremium(0, 4000)
 
           await policy.payCommissions()
 

--- a/test/policyPremiums.js
+++ b/test/policyPremiums.js
@@ -6,7 +6,7 @@ import {
   extractEventArgs,
   hdWallet,
   ADDRESS_ZERO,
-  createTranch,
+  createTranche,
   preSetupPolicy,
   doPolicyApproval,
   EvmClock,
@@ -35,13 +35,13 @@ const IPolicy = artifacts.require("./base/IPolicy")
 const DummyPolicyFacet = artifacts.require("./test/DummyPolicyFacet")
 const FreezeUpgradesFacet = artifacts.require("./test/FreezeUpgradesFacet")
 
-const premiumIntervalSeconds = 30
+// const premiumIntervalSeconds = 30
 
 const POLICY_ATTRS_1 = {
   initiationDateDiff: 1000,
   startDateDiff: 2000,
   maturationDateDiff: 3000,
-  premiumIntervalSeconds,
+  // premiumIntervalSeconds,
   claimsAdminCommissionBP: 0,
   brokerCommissionBP: 0,
   naymsCommissionBP: 0,
@@ -57,7 +57,7 @@ const POLICY_ATTRS_3 = Object.assign({}, POLICY_ATTRS_1, {
   initiationDateDiff: 1000,
   startDateDiff: 3000,
   maturationDateDiff: 6000,
-  premiumIntervalSeconds: 5000,
+  // premiumIntervalSeconds: 5000,
 })
 
 describe('Policy: Premiums', () => {
@@ -102,9 +102,9 @@ describe('Policy: Premiums', () => {
   let POLICY_STATE_APPROVED
   let POLICY_STATE_CANCELLED
 
-  let TRANCH_STATE_CANCELLED
-  let TRANCH_STATE_ACTIVE
-  let TRANCH_STATE_MATURED
+  let TRANCHE_STATE_CANCELLED
+  let TRANCHE_STATE_ACTIVE
+  let TRANCHE_STATE_MATURED
 
   let approvePolicy
   let setupPolicy
@@ -161,9 +161,9 @@ describe('Policy: Premiums', () => {
     POLICY_STATE_IN_APPROVAL = await policyStates.POLICY_STATE_IN_APPROVAL()
     POLICY_STATE_APPROVED = await policyStates.POLICY_STATE_APPROVED()
 
-    TRANCH_STATE_CANCELLED = await policyStates.TRANCH_STATE_CANCELLED()
-    TRANCH_STATE_ACTIVE = await policyStates.TRANCH_STATE_ACTIVE()
-    TRANCH_STATE_MATURED = await policyStates.TRANCH_STATE_MATURED()
+    TRANCHE_STATE_CANCELLED = await policyStates.TRANCHE_STATE_CANCELLED()
+    TRANCHE_STATE_ACTIVE = await policyStates.TRANCHE_STATE_ACTIVE()
+    TRANCHE_STATE_MATURED = await policyStates.TRANCHE_STATE_MATURED()
 
     // roles
     underwriter = await createEntity({ entityDeployer, adminAddress: underwriterRep, entityContext, acl })
@@ -218,11 +218,12 @@ describe('Policy: Premiums', () => {
       })
 
       it('empty premiums array is allowed', async () => {
-        await createTranch(policy, {
-          premiums: []
+        await createTranche(policy, {
+          // premiums: []
+          premiumsDiff: []
         }, { from: policyOwnerAddress })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           numPremiums_: 0,
           nextPremiumAmount_: 0,
           nextPremiumDueAt_: 0,
@@ -233,11 +234,12 @@ describe('Policy: Premiums', () => {
       })
 
       it('initially the first premium is expected by the inititation date', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           numPremiums_: 3,
           nextPremiumAmount_: 2,
           nextPremiumDueAt_: policyAttrs.initiationDate,
@@ -248,27 +250,30 @@ describe('Policy: Premiums', () => {
       })
 
       it('policy must have permission to transfer premium payment token', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 10 })
-        await policy.payTranchPremium(0, 2).should.be.rejectedWith('amount exceeds allowance')
+        await policy.payTranchePremium(0, 2).should.be.rejectedWith('amount exceeds allowance')
       })
 
       it('sender must have enough tokens to make the payment', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 1 })
         await etherToken.approve(policy.address, 2)
-        await policy.payTranchPremium(0, 2).should.be.rejectedWith('amount exceeds balance')
+        await policy.payTranchePremium(0, 2).should.be.rejectedWith('amount exceeds balance')
       })
 
       it('updates balances upon payment', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 2 })
@@ -277,7 +282,7 @@ describe('Policy: Premiums', () => {
         const payerPreBalance = await etherToken.balanceOf(accounts[0])
         const treasuryPreBalance = await etherToken.balanceOf(entity.address)
 
-        const ret = await policy.payTranchPremium(0, 2)
+        const ret = await policy.payTranchePremium(0, 2)
 
         const payerPostBalance = await etherToken.balanceOf(accounts[0])
         const treasuryPostBalance = await etherToken.balanceOf(entity.address)
@@ -287,41 +292,43 @@ describe('Policy: Premiums', () => {
       })
 
       it('emits an event upon payment', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 2 })
         await etherToken.approve(policy.address, 2)
-        const ret = await policy.payTranchPremium(0, 2)
+        const ret = await policy.payTranchePremium(0, 2)
 
         expect(extractEventArgs(ret, events.PremiumPayment)).to.include({
-          tranchIndex: '0',
+          trancheIndex: '0',
           amount: '2',
         })
       })
 
       it('updates the internal stats once first payment is made', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 2 })
         await etherToken.approve(policy.address, 2)
-        await policy.payTranchPremium(0, 2).should.be.fulfilled
+        await policy.payTranchePremium(0, 2).should.be.fulfilled
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           balance_: 2,
         })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           nextPremiumAmount_: 3,
           nextPremiumPaidSoFar_: 0,
           premiumPaymentsMissed_: 0,
           numPremiumsPaid_: 1,
         })
 
-        await policy.getTranchPremiumInfo(0, 0).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 0).should.eventually.matchObj({
           amount_: 2,
           dueAt_: policyAttrs.initiationDate,
           paidSoFar_: 2,
@@ -333,27 +340,28 @@ describe('Policy: Premiums', () => {
       })
 
       it('updates the internal stats and treasury once subsequent payment is made', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 5 })
         await etherToken.approve(policy.address, 5)
-        await policy.payTranchPremium(0, 2).should.be.fulfilled
-        await policy.payTranchPremium(0, 3).should.be.fulfilled
+        await policy.payTranchePremium(0, 2).should.be.fulfilled
+        await policy.payTranchePremium(0, 3).should.be.fulfilled
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           balance_: 5,
         })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           nextPremiumAmount_: 4,
           nextPremiumPaidSoFar_: 0,
           premiumPaymentsMissed_: 0,
           numPremiumsPaid_: 2,
         })
 
-        await policy.getTranchPremiumInfo(0, 1).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 1).should.eventually.matchObj({
           amount_: 3,
           dueAt_: policyAttrs.initiationDate + 30,
           paidSoFar_: 3,
@@ -365,56 +373,56 @@ describe('Policy: Premiums', () => {
       })
 
       it('partial payments allowed', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 2 })
         await etherToken.approve(policy.address, 2)
 
-        let ret = await policy.payTranchPremium(0, 1).should.be.fulfilled
+        let ret = await policy.payTranchePremium(0, 1).should.be.fulfilled
 
         expect(extractEventArgs(ret, events.PremiumPayment)).to.include({
-          tranchIndex: '0',
+          trancheIndex: '0',
           amount: '1',
         })
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           balance_: 1,
         })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           nextPremiumAmount_: 2,
           nextPremiumPaidSoFar_: 1,
           premiumPaymentsMissed_: 0,
           numPremiumsPaid_: 0,
         })
 
-        await policy.getTranchPremiumInfo(0, 0).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 0).should.eventually.matchObj({
           amount_: 2,
           dueAt_: policyAttrs.initiationDate,
           paidSoFar_: 1,
         })
 
-        ret = await policy.payTranchPremium(0, 1).should.be.fulfilled
+        ret = await policy.payTranchePremium(0, 1).should.be.fulfilled
 
         expect(extractEventArgs(ret, events.PremiumPayment)).to.include({
-          tranchIndex: '0',
+          trancheIndex: '0',
           amount: '1',
         })
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           balance_: 2,
         })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           nextPremiumAmount_: 3,
           nextPremiumPaidSoFar_: 0,
           premiumPaymentsMissed_: 0,
           numPremiumsPaid_: 1,
         })
 
-        await policy.getTranchPremiumInfo(0, 0).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 0).should.eventually.matchObj({
           amount_: 2,
           dueAt_: policyAttrs.initiationDate,
           paidSoFar_: 2,
@@ -426,40 +434,41 @@ describe('Policy: Premiums', () => {
       })
 
       it('overpayments allowed', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 3 })
         await etherToken.approve(policy.address, 3)
 
-        let ret = await policy.payTranchPremium(0, 3).should.be.fulfilled
+        let ret = await policy.payTranchePremium(0, 3).should.be.fulfilled
 
         expect(extractEventArgs(ret, events.PremiumPayment)).to.include({
-          tranchIndex: '0',
+          trancheIndex: '0',
           amount: '3',
         })
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           balance_: 3,
         })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           nextPremiumAmount_: 3,
           nextPremiumPaidSoFar_: 1,
           premiumPaymentsMissed_: 0,
           numPremiumsPaid_: 1,
         })
 
-        await policy.getTranchPremiumInfo(0, 0).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 0).should.eventually.matchObj({
           amount_: 2,
           dueAt_: policyAttrs.initiationDate,
           paidSoFar_: 2,
         })
 
-        await policy.getTranchPremiumInfo(0, 1).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 1).should.eventually.matchObj({
           amount_: 3,
-          dueAt_: policyAttrs.initiationDate + premiumIntervalSeconds,
+          dueAt_: policyAttrs.initiationDate + 30,
           paidSoFar_: 1,
         })
 
@@ -469,46 +478,47 @@ describe('Policy: Premiums', () => {
       })
 
       it('can overpay the entire thing in one go', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await etherToken.deposit({ value: 20 })
         await etherToken.approve(policy.address, 20)
 
-        let ret = await policy.payTranchPremium(0, 20).should.be.fulfilled
+        let ret = await policy.payTranchePremium(0, 20).should.be.fulfilled
 
         expect(extractEventArgs(ret, events.PremiumPayment)).to.include({
-          tranchIndex: '0',
+          trancheIndex: '0',
           amount: '9',
         })
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           balance_: 9,
         })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           nextPremiumAmount_: 0,
           nextPremiumPaidSoFar_: 0,
           premiumPaymentsMissed_: 0,
           numPremiumsPaid_: 3,
         })
 
-        await policy.getTranchPremiumInfo(0, 0).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 0).should.eventually.matchObj({
           amount_: 2,
           dueAt_: policyAttrs.initiationDate,
           paidSoFar_: 2,
         })
 
-        await policy.getTranchPremiumInfo(0, 1).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 1).should.eventually.matchObj({
           amount_: 3,
-          dueAt_: policyAttrs.initiationDate + premiumIntervalSeconds,
+          dueAt_: policyAttrs.initiationDate + 30,
           paidSoFar_: 3,
         })
 
-        await policy.getTranchPremiumInfo(0, 2).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 2).should.eventually.matchObj({
           amount_: 4,
-          dueAt_: policyAttrs.initiationDate + premiumIntervalSeconds * 2,
+          dueAt_: policyAttrs.initiationDate + 30 * 2,
           paidSoFar_: 4,
         })
 
@@ -527,11 +537,12 @@ describe('Policy: Premiums', () => {
       })
 
       it('0-values are skipped over when it comes to the first payment', async () => {
-        await createTranch(policy, {
-          premiums: [0, 0, 0, 2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [0, 0, 0, 2, 3, 4]
+          premiumsDiff: [0, 0, 30, 0, 60, 0, 90, 2, 120, 3, 150, 4]
         }, { from: policyOwnerAddress })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           numPremiums_: 3,
           nextPremiumAmount_: 2,
           nextPremiumDueAt_: policyAttrs.initiationDate + (30 * 3),
@@ -542,13 +553,13 @@ describe('Policy: Premiums', () => {
 
         await etherToken.deposit({ value: 2 })
         await etherToken.approve(policy.address, 2)
-        await policy.payTranchPremium(0, 2)
+        await policy.payTranchePremium(0, 2)
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
           balance_: 2,
         })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           nextPremiumAmount_: 3,
           nextPremiumPaidSoFar_: 0,
           premiumPaymentsMissed_: 0,
@@ -561,11 +572,12 @@ describe('Policy: Premiums', () => {
       })
 
       it('0-values are skipped over for subsequent payments too', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 0, 4, 0, 0, 5, 0]
+        await createTranche(policy, {
+          // premiums: [2, 3, 0, 4, 0, 0, 5, 0]
+          premiumsDiff: [0, 2, 30, 3, 60, 0, 90, 4, 120, 0, 150, 0, 180, 5, 210, 0]
         }, { from: policyOwnerAddress })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           numPremiums_: 4,
           nextPremiumAmount_: 2,
           nextPremiumDueAt_: policyAttrs.initiationDate,
@@ -574,28 +586,28 @@ describe('Policy: Premiums', () => {
           numPremiumsPaid_: 0,
         })
 
-        await policy.getTranchPremiumInfo(0, 0).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 0).should.eventually.matchObj({
           amont_: 2,
           dueAt_: policyAttrs.initiationDate,
           paidAt_: 0,
           paidBy_: ADDRESS_ZERO,
         })
 
-        await policy.getTranchPremiumInfo(0, 1).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 1).should.eventually.matchObj({
           amont_: 3,
           dueAt_: policyAttrs.initiationDate + 30,
           paidAt_: 0,
           paidBy_: ADDRESS_ZERO,
         })
 
-        await policy.getTranchPremiumInfo(0, 2).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 2).should.eventually.matchObj({
           amont_: 4,
           dueAt_: policyAttrs.initiationDate + (30 * 3),
           paidAt_: 0,
           paidBy_: ADDRESS_ZERO,
         })
 
-        await policy.getTranchPremiumInfo(0, 3).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 3).should.eventually.matchObj({
           amont_: 5,
           dueAt_: policyAttrs.initiationDate + (30 * 6),
           paidAt_: 0,
@@ -605,12 +617,12 @@ describe('Policy: Premiums', () => {
         // pay them all
         await etherToken.deposit({ value: 40 })
         await etherToken.approve(policy.address, 40)
-        await policy.payTranchPremium(0, 2)
-        await policy.payTranchPremium(0, 3)
-        await policy.payTranchPremium(0, 4)
-        await policy.payTranchPremium(0, 5)
+        await policy.payTranchePremium(0, 2)
+        await policy.payTranchePremium(0, 3)
+        await policy.payTranchePremium(0, 4)
+        await policy.payTranchePremium(0, 5)
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           numPremiums_: 4,
           nextPremiumAmount_: 0,
           nextPremiumDueAt_: 0,
@@ -621,11 +633,12 @@ describe('Policy: Premiums', () => {
       })
 
       it('0-values are skipped over for bulk payments too', async () => {
-        await createTranch(policy, {
-          premiums: [2, 3, 0, 4, 0, 0, 5, 0]
+        await createTranche(policy, {
+          // premiums: [2, 3, 0, 4, 0, 0, 5, 0]
+          premiumsDiff: [0, 2, 30, 3, 60, 0, 90, 4, 120, 0, 150, 0, 180, 5, 210, 0]
         }, { from: policyOwnerAddress })
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           numPremiums_: 4,
           nextPremiumAmount_: 2,
           nextPremiumDueAt_: policyAttrs.initiationDate,
@@ -634,28 +647,28 @@ describe('Policy: Premiums', () => {
           numPremiumsPaid_: 0,
         })
 
-        await policy.getTranchPremiumInfo(0, 0).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 0).should.eventually.matchObj({
           amont_: 2,
           dueAt_: policyAttrs.initiationDate,
           paidAt_: 0,
           paidBy_: ADDRESS_ZERO,
         })
 
-        await policy.getTranchPremiumInfo(0, 1).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 1).should.eventually.matchObj({
           amont_: 3,
           dueAt_: policyAttrs.initiationDate + 30,
           paidAt_: 0,
           paidBy_: ADDRESS_ZERO,
         })
 
-        await policy.getTranchPremiumInfo(0, 2).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 2).should.eventually.matchObj({
           amont_: 4,
           dueAt_: policyAttrs.initiationDate + (30 * 3),
           paidAt_: 0,
           paidBy_: ADDRESS_ZERO,
         })
 
-        await policy.getTranchPremiumInfo(0, 3).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 3).should.eventually.matchObj({
           amont_: 5,
           dueAt_: policyAttrs.initiationDate + (30 * 6),
           paidAt_: 0,
@@ -665,9 +678,9 @@ describe('Policy: Premiums', () => {
         // pay them all
         await etherToken.deposit({ value: 40 })
         await etherToken.approve(policy.address, 40)
-        await policy.payTranchPremium(0, 7)
+        await policy.payTranchePremium(0, 7)
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           numPremiums_: 4,
           nextPremiumAmount_: 4,
           nextPremiumDueAt_: policyAttrs.initiationDate + (30 * 3),
@@ -676,7 +689,7 @@ describe('Policy: Premiums', () => {
           numPremiumsPaid_: 2,
         })
 
-        await policy.getTranchPremiumInfo(0, 2).should.eventually.matchObj({
+        await policy.getTranchePremiumInfo(0, 2).should.eventually.matchObj({
           amount_: 4,
           dueAt_: policyAttrs.initiationDate + (30 * 3),
           paidSoFar_: 2,
@@ -688,8 +701,9 @@ describe('Policy: Premiums', () => {
       beforeEach(async () => {
         await setupPolicy(POLICY_ATTRS_2)
 
-        await createTranch(policy, {
-          premiums: [2, 3, 4]
+        await createTranche(policy, {
+          // premiums: [2, 3, 4]
+          premiumsDiff: [0, 2, 30, 3, 60, 4]
         }, { from: policyOwnerAddress })
 
         await approvePolicy()
@@ -700,7 +714,7 @@ describe('Policy: Premiums', () => {
 
         await evmClock.setAbsoluteTime(initiationDate)
 
-        await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+        await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
           premiumPaymentsMissed_: 1,
           nextPremiumAmount_: 2,
           nextPremiumPaidSoFar_: 0,
@@ -709,26 +723,27 @@ describe('Policy: Premiums', () => {
 
         await etherToken.deposit({ value: 5 })
         await etherToken.approve(policy.address, 5)
-        await policy.payTranchPremium(0, 2).should.be.rejectedWith('payment too late')
+        await policy.payTranchePremium(0, 2).should.be.rejectedWith('payment too late')
       })
     })
 
     it('if all premiums are paid before initiation that is ok', async () => {
       await setupPolicy(POLICY_ATTRS_1)
 
-      await createTranch(policy, {
-        premiums: [2, 3, 5]
+      await createTranche(policy, {
+        // premiums: [2, 3, 5]
+        premiumsDiff: [0, 2, 30, 3, 60, 4]
       }, { from: policyOwnerAddress })
 
       await approvePolicy()
 
       await etherToken.deposit({ value: 100 })
       await etherToken.approve(policy.address, 100)
-      await policy.payTranchPremium(0, 2).should.be.fulfilled // 2
-      await policy.payTranchPremium(0, 3).should.be.fulfilled // 3
-      await policy.payTranchPremium(0, 5).should.be.fulfilled // 5
+      await policy.payTranchePremium(0, 2).should.be.fulfilled // 2
+      await policy.payTranchePremium(0, 3).should.be.fulfilled // 3
+      await policy.payTranchePremium(0, 5).should.be.fulfilled // 5
 
-      await policy.getTranchPremiumsInfo(0).should.eventually.matchObj({
+      await policy.getTranchePremiumsInfo(0).should.eventually.matchObj({
         premiumPaymentsMissed_: 0,
         nextPremiumAmount_: 0,
         nextPremiumDueAt_: 0,
@@ -740,21 +755,22 @@ describe('Policy: Premiums', () => {
     it('will not accept extra payments', async () => {
       await setupPolicy(POLICY_ATTRS_1)
 
-      await createTranch(policy, {
-        premiums: [2, 3, 4, 5]
+      await createTranche(policy, {
+        // premiums: [2, 3, 4, 5]
+        premiumsDiff: [0, 2, 30, 3, 60, 4, 90, 5]
       }, { from: policyOwnerAddress })
 
       await approvePolicy()
 
       await etherToken.deposit({ value: 100 })
       await etherToken.approve(policy.address, 100)
-      await policy.payTranchPremium(0, 2).should.be.fulfilled // 2
-      await policy.payTranchPremium(0, 3).should.be.fulfilled // 3
-      await policy.payTranchPremium(0, 4).should.be.fulfilled // 4
-      await policy.payTranchPremium(0, 5).should.be.fulfilled // 5
+      await policy.payTranchePremium(0, 2).should.be.fulfilled // 2
+      await policy.payTranchePremium(0, 3).should.be.fulfilled // 3
+      await policy.payTranchePremium(0, 4).should.be.fulfilled // 4
+      await policy.payTranchePremium(0, 5).should.be.fulfilled // 5
 
       const bal = await etherToken.balanceOf(accounts[0])
-      await policy.payTranchPremium(0, 1).should.be.fulfilled // shouldn't take any money
+      await policy.payTranchePremium(0, 1).should.be.fulfilled // shouldn't take any money
       await etherToken.balanceOf(accounts[0]).should.eventually.eq(bal)
     })
 
@@ -762,8 +778,11 @@ describe('Policy: Premiums', () => {
       beforeEach(async () => {
         await setupPolicy(POLICY_ATTRS_3)
 
-        await createTranch(policy, {
-          premiums: [2, 3]
+        await createTranche(policy, {
+          // premiums: [2, 3]
+          // premiumsDiff: [0, 2, 30, 3]
+          // Todo: premium interval cannot be 5000
+          premiumsDiff: [0, 2, 500, 3]
         }, { from: policyOwnerAddress })
 
         await approvePolicy()
@@ -772,21 +791,21 @@ describe('Policy: Premiums', () => {
         await etherToken.approve(policy.address, 100)
 
         // pay first premium
-        await policy.payTranchPremium(0, 2).should.be.fulfilled
+        await policy.payTranchePremium(0, 2).should.be.fulfilled
 
         // kick-off sale
         await evmClock.setAbsoluteTime(preSetupPolicyCtx.policies.get(POLICY_ATTRS_3).attrs.initiationDate)
         await policy.checkAndUpdateState()
       })
 
-      it('if tranch is already cancelled', async () => {
+      it('if tranche is already cancelled', async () => {
         // shift to start date
         await evmClock.setAbsoluteTime(preSetupPolicyCtx.policies.get(POLICY_ATTRS_3).attrs.startDate)
         // should auto-call heartbeat in here
-        await policy.payTranchPremium(0, 3).should.be.rejectedWith('payment not allowed')
+        await policy.payTranchePremium(0, 3).should.be.rejectedWith('payment not allowed')
 
-        await policy.getTranchInfo(0).should.eventually.matchObj({
-          _state: TRANCH_STATE_CANCELLED,
+        await policy.getTrancheInfo(0).should.eventually.matchObj({
+          _state: TRANCHE_STATE_CANCELLED,
         })
       })
     })

--- a/test/treasury.js
+++ b/test/treasury.js
@@ -8,7 +8,7 @@ import {
   BYTES_ZERO,
   createEntity,
   createPolicy,
-  createTranch,
+  createTranche,
 } from './utils'
 
 import { events } from '..'


### PR DESCRIPTION
Premiums are now specified as follows:
[date1, premium1, date2, premium2, ...]

Removed premiumInterval. From now on the premiums can be specified at any time between the initiation and maturation dates.

calculateMaxNumOfPremiums() has been removed as it is no longer needed. Instead, the policy constructor checks to make sure the premiums are in increasing order and between the initiation date and the maturation date.


Updated unit tests to take permiumsDiff instead of premiums and tranchData
Diff instead of tranchData. These inputs include the premium input in the new format, but with the time difference from the initiation date rather than an absolute date.

Also fixed typo. Tranche is spelled "tranche" everywhere :)
