### PR TITLE
[CU-256wbgh] Fix CircleCI job filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,16 +139,14 @@ workflows:
             - deploy_contracts
           filters:
             branches:
-              ignore:
-                - gh-pages
+              only:
                 - master
       - publish_to_npm:
           requires:
             - deploy_contracts
           filters:
             branches:
-              ignore:
-                - gh-pages
+              only:
                 - master
       - git_tag:
           requires:


### PR DESCRIPTION
Latest changes to the CI job filtering fail to deploy the admin dapp and publish to npm. This PR is to fix that.

ClickUp: [CU-256wbgh](https://app.clickup.com/t/256wbgh)