### PR TITLE
CU-25cft8q: Fix execute limit offer panel in admin dapp

### DIFF
--- a/contracts/admin.json
+++ b/contracts/admin.json
@@ -2244,19 +2244,12 @@
         {
           "name": "_notify",
           "title": "Notify",
-          "type": "address",
-          "validation": [
-            {
-              "type": "allowedTypes",
-              "contract": true
-            }
-          ]
+          "type": "address"
         },
         {
           "name": "_notifyData",
           "title": "Notify Data",
-          "type": "bytes32",
-          "optional": true
+          "type": "string"
         }
       ],
       "execs": [


### PR DESCRIPTION
### Summary

Due to a limitation in the solUI, it is not possible to define an input field of `byte` type. As a workaround, field can be declared to be of type `string` and provided with a dummy input which can be implicitly converted to expected type.

This PR is to address that and change the type of `_notifyData` argument to string in solUI spec.

ClickUp: [CU-25cft8q](https://app.clickup.com/t/25cft8q)