### PR TITLE
[CU #2gwxbhh] Emit event when Offer gets created

### DIFF
--- a/contracts/MarketCoreFacet.sol
+++ b/contracts/MarketCoreFacet.sol
@@ -300,6 +300,8 @@ contract MarketCoreFacet is EternalStorage, Controller, MarketFacetBase, IDiamon
             require(IERC20(_sellToken).transferFrom(msg.sender, address(this), _sellAmount), "unable to escrow tokens");
         }
 
+        emit OfferCreated(id, _sellToken, _buyToken);
+        
         return id;
     }
 

--- a/contracts/base/IMarketCoreFacet.sol
+++ b/contracts/base/IMarketCoreFacet.sol
@@ -2,6 +2,15 @@
 pragma solidity >=0.8.9;
 
 interface IMarketCoreFacet {
+
+    /**
+     * @dev Emitted when an offer gets created
+     * @param id ID of the offer created
+     * @param sellToken The address the token being sold
+     * @param buyToken The address the token being bought
+     */
+    event OfferCreated(uint256 indexed id, address indexed sellToken, address indexed buyToken);
+
     /**
      * @dev Execute a limit offer with an observer attached.
      *

--- a/test/market.js
+++ b/test/market.js
@@ -1,6 +1,7 @@
-import { expect, ADDRESS_ZERO, BYTES_ZERO, EvmSnapshot } from './utils/index'
+import { expect, ADDRESS_ZERO, BYTES_ZERO, EvmSnapshot, extractEventArgs } from './utils/index'
 import { toBN, toWei, toHex } from './utils/web3'
 
+import { events } from '../'
 import { getAccounts } from '../deploy/utils'
 import { ensureAclIsDeployed } from '../deploy/modules/acl'
 import { ensureSettingsIsDeployed } from '../deploy/modules/settings'
@@ -456,6 +457,38 @@ describe('Market', () => {
           FEE_SCHEDULE_PLATFORM_ACTION
         ).should.be.fulfilled
       })
+    })
+  })
+
+  describe('event', () => {
+    it('is emitted after creation', async () => {
+      const pay_amt = toWei('10')
+      const buy_amt = toWei('10')
+
+      await erc20WETH.approve(
+        market.address,
+        pay_amt,
+        { from: accounts[2] }
+      ).should.be.fulfilled
+
+      const result = await market.executeLimitOffer(
+        erc20WETH.address,
+        pay_amt,
+        erc20DAI.address,
+        buy_amt,
+        FEE_SCHEDULE_STANDARD,
+        ADDRESS_ZERO, 
+        BYTES_ZERO,
+        { from: accounts[2] }
+      )
+
+      const eventArgs = extractEventArgs(result, events.OfferCreated)
+
+      expect(eventArgs).to.include({
+        sellToken: erc20WETH.address,
+        buyToken: erc20DAI.address,
+      })
+
     })
   })
 


### PR DESCRIPTION
Every time an offer gets created `OfferCreated` event should be emitted with following properties:

- `id` - ID of the offer created
- `sellToken` The address the token being sold
- `buyToken` The address the token being bought


ClickUp: [#2gwxbhh](https://app.clickup.com/t/2gwxbhh)